### PR TITLE
feat: Add share buttons and relocate language switcher

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,46 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { Button } from "@/components/ui/button";
-import { Phone, Menu, X, MessageCircleCode, ChevronDown, Globe } from "lucide-react";
-import { Link, useLocation } from "react-router-dom";
+import { Phone, Menu, X, MessageCircleCode, ChevronDown } from "lucide-react";
+import { Link } from "react-router-dom";
 import { NavigationMenu, NavigationMenuContent, NavigationMenuItem, NavigationMenuLink, NavigationMenuList, NavigationMenuTrigger } from "@/components/ui/navigation-menu";
-import { useLanguage } from '@/contexts/LanguageContext';
 import { cn } from '@/lib/utils';
-
-const LanguageSwitcher = () => {
-  const { currentLanguage, setLanguage } = useLanguage();
-  const location = useLocation();
-  
-  // Only show language switcher on Learn pages
-  const isLearnPage = location.pathname.startsWith('/blog') || 
-                     location.pathname.startsWith('/patient-guides') ||
-                     location.pathname.startsWith('/faqs') ||
-                     location.pathname.startsWith('/resources');
-
-  if (!isLearnPage) return null;
-
-  return (
-    <div className="flex items-center gap-1">
-      <Globe size={16} className="text-muted-foreground" />
-      <div className="flex bg-muted rounded-md p-1">
-        {[
-          { code: 'en', label: 'EN' },
-          { code: 'te', label: 'తె' },
-          { code: 'hi', label: 'हि' }
-        ].map(({ code, label }) => (
-          <Button
-            key={code}
-            size="sm"
-            variant={currentLanguage === code ? "default" : "ghost"}
-            className="h-6 px-2 text-xs"
-            onClick={() => setLanguage(code as any)}
-          >
-            {label}
-          </Button>
-        ))}
-      </div>
-    </div>
-  );
-};
 
 const Header = () => {
   const [isScrolled, setIsScrolled] = useState(false);
@@ -197,7 +160,6 @@ const Header = () => {
                     <div className="grid w-[500px] grid-cols-2 gap-3 p-4 bg-popover">
                       <div className="col-span-2 mb-2 flex items-center justify-between">
                         <span className="text-sm font-medium">Health Education</span>
-                        <LanguageSwitcher />
                       </div>
                       <NavigationMenuLink asChild>
                         <Link
@@ -314,7 +276,6 @@ const Header = () => {
             <div className="space-y-2">
               <div className="flex items-center justify-between">
                 <span className="block font-medium text-primary">Learn</span>
-                <LanguageSwitcher />
               </div>
               <Link to="/blog" className="block pl-4 text-sm hover:text-primary transition-colors" onClick={() => setIsMobileMenuOpen(false)}>Blog</Link>
               <Link to="/patient-guides" className="block pl-4 text-sm hover:text-primary transition-colors" onClick={() => setIsMobileMenuOpen(false)}>Patient Guides</Link>

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Button } from "@/components/ui/button";
+import { Globe } from "lucide-react";
+import { useLanguage } from '@/contexts/LanguageContext';
+
+export const LanguageSwitcher = () => {
+  const { currentLanguage, setLanguage } = useLanguage();
+
+  return (
+    <div className="flex items-center gap-1">
+      <Globe size={16} className="text-muted-foreground" />
+      <div className="flex bg-muted rounded-md p-1">
+        {[
+          { code: 'en', label: 'EN' },
+          { code: 'te', label: 'తె' },
+          { code: 'hi', label: 'हि' }
+        ].map(({ code, label }) => (
+          <Button
+            key={code}
+            size="sm"
+            variant={currentLanguage === code ? "default" : "ghost"}
+            className="h-6 px-2 text-xs"
+            onClick={() => setLanguage(code as any)}
+          >
+            {label}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -10,6 +10,7 @@ import { useLanguage } from '@/contexts/LanguageContext';
 import { supabase } from '@/integrations/supabase/client';
 import { TranslatedText } from '@/components/TranslatedText';
 import { Skeleton } from '@/components/ui/skeleton';
+import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 
 // Define types for our data
 export interface Category {
@@ -110,9 +111,12 @@ const BlogPage = () => {
         <div className="container mx-auto px-4 py-8">
           <div className="max-w-6xl mx-auto">
             <div className="text-center mb-12">
-              <h1 className="text-4xl font-heading font-bold text-primary mb-4">
-                {t('learn.blog.title', 'Health Blog')}
-              </h1>
+              <div className="flex justify-center items-center gap-4 mb-4">
+                <h1 className="text-4xl font-heading font-bold text-primary">
+                  {t('learn.blog.title', 'Health Blog')}
+                </h1>
+                <LanguageSwitcher />
+              </div>
               <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
                 {t('learn.blog.subtitle', 'Latest health tips and medical insights')}
               </p>

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -1,15 +1,18 @@
 import React, { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Calendar, User, Clock } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Calendar, User, Clock, Share2, ArrowLeft } from 'lucide-react';
 import { useLanguage } from '@/contexts/LanguageContext';
+import { useToast } from '@/components/ui/use-toast';
 import { supabase } from '@/integrations/supabase/client';
 import { TranslatedText } from '@/components/TranslatedText';
 import { useTranslatedContent } from '@/hooks/useTranslatedContent';
 import { Skeleton } from '@/components/ui/skeleton';
+import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 
 interface Post {
   id: number;
@@ -44,6 +47,33 @@ const BlogPostPage = () => {
   const { t } = useLanguage();
   const [post, setPost] = useState<Post | null>(null);
   const [loading, setLoading] = useState(true);
+  const { toast } = useToast();
+
+  const handleShare = async () => {
+    const shareData = {
+      title: post.title,
+      text: `Check out this article from OrthoLife: ${post.title}`,
+      url: window.location.href,
+    };
+    try {
+      if (navigator.share && post) {
+        await navigator.share(shareData);
+      } else {
+        await navigator.clipboard.writeText(window.location.href);
+        toast({
+          title: "Link Copied!",
+          description: "The article link has been copied to your clipboard.",
+        });
+      }
+    } catch (error) {
+      console.error("Failed to share:", error);
+      toast({
+        title: "Error",
+        description: "Could not share the article.",
+        variant: "destructive",
+      });
+    }
+  };
 
   // Helper function to strip HTML tags and truncate text
   const createExcerpt = (content: string, maxLength: number = 160): string => {
@@ -161,7 +191,10 @@ const BlogPostPage = () => {
             {!loading && post && (
               <article>
                 <header className="mb-8">
-                  <Badge className="mb-4"><TranslatedText>{post.categories.name}</TranslatedText></Badge>
+                  <div className="flex justify-between items-center mb-4">
+                    <Badge><TranslatedText>{post.categories.name}</TranslatedText></Badge>
+                    <LanguageSwitcher />
+                  </div>
                   <h1 className="text-4xl font-heading font-bold text-primary mb-4">
                     <TranslatedText>{post.title}</TranslatedText>
                   </h1>
@@ -184,6 +217,21 @@ const BlogPostPage = () => {
                 <img src={post.image_url} alt={post.title} className="w-full h-auto rounded-lg mb-8" />
 
                 <TranslatedContent htmlContent={post.content} />
+
+                <div className="mt-8 pt-8 border-t">
+                  <div className="flex justify-between items-center">
+                    <Button asChild variant="outline">
+                      <Link to="/blog">
+                        <ArrowLeft className="mr-2 h-4 w-4" />
+                        Back to Blog
+                      </Link>
+                    </Button>
+                    <Button onClick={handleShare}>
+                      <Share2 className="mr-2 h-4 w-4" />
+                      Share Article
+                    </Button>
+                  </div>
+                </div>
               </article>
             )}
 

--- a/src/pages/FAQPage.tsx
+++ b/src/pages/FAQPage.tsx
@@ -9,6 +9,7 @@ import { Search, HelpCircle, Phone, MessageCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { TranslatedText } from '@/components/TranslatedText';
+import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 
 const FAQPage = () => {
   const { t } = useLanguage();
@@ -116,9 +117,12 @@ const FAQPage = () => {
         <div className="container mx-auto px-4 py-8">
           <div className="max-w-4xl mx-auto">
             <div className="text-center mb-12">
-              <h1 className="text-4xl font-heading font-bold text-primary mb-4">
-                {t('learn.faqs.title', 'Frequently Asked Questions')}
-              </h1>
+              <div className="flex justify-center items-center gap-4 mb-4">
+                <h1 className="text-4xl font-heading font-bold text-primary">
+                  {t('learn.faqs.title', 'Frequently Asked Questions')}
+                </h1>
+                <LanguageSwitcher />
+              </div>
               <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
                 {t('learn.faqs.subtitle', 'Quick answers to common health questions')}
               </p>

--- a/src/pages/PatientGuidesPage.tsx
+++ b/src/pages/PatientGuidesPage.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { BookOpen, Download, Eye, Clock } from 'lucide-react';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { TranslatedText } from '@/components/TranslatedText';
+import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 
 const PatientGuidesPage = () => {
   const { t } = useLanguage();
@@ -109,9 +110,12 @@ const PatientGuidesPage = () => {
         <div className="container mx-auto px-4 py-8">
           <div className="max-w-6xl mx-auto">
             <div className="text-center mb-12">
-              <h1 className="text-4xl font-heading font-bold text-primary mb-4">
-                {t('learn.guides.title', 'Patient Guides')}
-              </h1>
+              <div className="flex justify-center items-center gap-4 mb-4">
+                <h1 className="text-4xl font-heading font-bold text-primary">
+                  {t('learn.guides.title', 'Patient Guides')}
+                </h1>
+                <LanguageSwitcher />
+              </div>
               <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
                 {t('learn.guides.subtitle', 'Comprehensive guides for better health management')}
               </p>

--- a/src/pages/ResourcesPage.tsx
+++ b/src/pages/ResourcesPage.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { ExternalLink, Download, Calculator, Calendar, FileText, Smartphone, Globe, BookOpen } from 'lucide-react';
 import { useLanguage } from '@/contexts/LanguageContext';
+import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 
 const ResourcesPage = () => {
   const { t } = useLanguage();
@@ -125,9 +126,12 @@ const ResourcesPage = () => {
         <div className="container mx-auto px-4 py-8">
           <div className="max-w-6xl mx-auto">
             <div className="text-center mb-12">
-              <h1 className="text-4xl font-heading font-bold text-primary mb-4">
-                {t('learn.resources.title', 'Health Resources')}
-              </h1>
+              <div className="flex justify-center items-center gap-4 mb-4">
+                <h1 className="text-4xl font-heading font-bold text-primary">
+                  {t('learn.resources.title', 'Health Resources')}
+                </h1>
+                <LanguageSwitcher />
+              </div>
               <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
                 {t('learn.resources.subtitle', 'Useful tools and resources for your health journey')}
               </p>


### PR DESCRIPTION
This commit implements two user-requested features:

1.  Adds "Share Article" and "Back to Blog" buttons to the blog post page. The share functionality uses the Web Share API where available, falling back to copying the link to the clipboard.

2.  Relocates the language switcher to be displayed on all "Learn" section pages. The `LanguageSwitcher` component has been extracted from the `Header` and is now included directly on the `BlogPage`, `BlogPostPage`, `PatientGuidesPage`, `FAQPage`, and `ResourcesPage` for better visibility.