### PR TITLE
fix: Address i18next missing key and complete component refactoring

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -22,6 +22,9 @@ i18n
       caches: ['localStorage'],
     },
 
+    ns: ['common'],
+    defaultNS: 'common',
+
     interpolation: {
       escapeValue: false, // react already safes from xss
     },


### PR DESCRIPTION
- Fixes a missing key error by setting the default namespace to 'common' in the i18next configuration.
- Completes the refactoring of all pages that were using the old `TranslatedText` component (`FAQPage`, `ResourcesPage`, `PatientGuidesPage`) to use the new `i18next` `t()` function.
- Moves all static content from these pages into the main translation JSON files.
- This commit finalizes the full migration to the new i18next-based translation system.