### PR TITLE
feat: Implement PWA installation for OrthoLife Patient App

### DIFF
--- a/public/favicon/site.webmanifest
+++ b/public/favicon/site.webmanifest
@@ -1,1 +1,1 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{"name":"OrthoLife","short_name":"OrthoLife","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone", "start_url": "/"}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -81,6 +81,7 @@
   "resources.tool3.description": "Monitor your post-surgery recovery milestones and exercises.",
 
   "resources.apps.title": "Mobile Apps",
+  "resources.apps.install": "Install App",
   "resources.app1.title": "OrthoLife Patient App",
   "resources.app1.description": "Book appointments, view reports, and access your medical records.",
   "resources.app2.title": "Exercise & Recovery",

--- a/src/pages/ResourcesPage.tsx
+++ b/src/pages/ResourcesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -20,6 +20,34 @@ import RecoveryProgressTracker from '@/components/RecoveryProgressTracker';
 
 const ResourcesPage = () => {
   const { t } = useTranslation();
+  const [installPrompt, setInstallPrompt] = useState<Event | null>(null);
+
+  useEffect(() => {
+    const handleBeforeInstallPrompt = (e: Event) => {
+      e.preventDefault();
+      setInstallPrompt(e);
+    };
+
+    window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+
+    return () => {
+      window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt);
+    };
+  }, []);
+
+  const handleInstallClick = () => {
+    if (installPrompt) {
+      (installPrompt as any).prompt();
+      (installPrompt as any).userChoice.then((choiceResult: { outcome: string }) => {
+        if (choiceResult.outcome === 'accepted') {
+          console.log('User accepted the install prompt');
+        } else {
+          console.log('User dismissed the install prompt');
+        }
+        setInstallPrompt(null);
+      });
+    }
+  };
 
   const toolsAndCalculators = [
     { id: 1, titleKey: 'resources.tool1.title', descriptionKey: 'resources.tool1.description', icon: Calculator, type: 'Interactive Tool', component: <BMICalculator /> },
@@ -137,10 +165,16 @@ const ResourcesPage = () => {
                             <Badge key={platform} variant="outline">{platform}</Badge>
                           ))}
                         </div>
-                        <div className="flex gap-2">
-                          <Button size="sm">App Store</Button>
-                          <Button size="sm" variant="outline">Play Store</Button>
-                        </div>
+                        {app.id === 1 && installPrompt ? (
+                          <Button size="sm" onClick={handleInstallClick}>
+                            {t('resources.apps.install')}
+                          </Button>
+                        ) : (
+                          <div className="flex gap-2">
+                            <Button size="sm" disabled={app.id === 1}>App Store</Button>
+                            <Button size="sm" variant="outline" disabled={app.id === 1}>Play Store</Button>
+                          </div>
+                        )}
                       </div>
                     </CardContent>
                   </Card>


### PR DESCRIPTION
This commit adds the functionality to install the website as a Progressive Web App (PWA) from the resources page.

- The `site.webmanifest` has been updated with the app name and start URL.
- The `ResourcesPage.tsx` component now includes logic to handle the PWA installation prompt.
- The "OrthoLife Patient App" card on the resources page now displays an "Install App" button when PWA installation is available.