### PR TITLE
fix(blog): Prevent 'load more' button from disappearing on language c…

### DIFF
--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -94,7 +94,7 @@ const BlogPage = () => {
     };
 
     fetchPosts();
-  }, [selectedCategory, page, i18n.language]);
+  }, [selectedCategory, page]);
 
   const handleCategoryClick = (categoryId: number | null) => {
     if (categoryId === null) {


### PR DESCRIPTION
…hange

Removed `i18n.language` from the dependency array of the `useEffect` hook responsible for fetching posts in `BlogPage.tsx`.

The component already fetches all available translations for posts, and client-side logic handles displaying the correct language. Re-fetching on language change was unnecessary and caused a state update that incorrectly hid the 'load more' button.