### PR TITLE
feat: Style WhatsAppMe page to display patient and calendar data

### DIFF
--- a/src/pages/WhatsAppMe.tsx
+++ b/src/pages/WhatsAppMe.tsx
@@ -1,16 +1,26 @@
 import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Phone, MessageSquare, Home, Building, FlaskConical, User, Users, Clipboard, Link, Calendar } from 'lucide-react';
+import { Phone, MessageSquare, Home, Building, FlaskConical, User, Users, Clipboard, Link, Calendar, Folder } from 'lucide-react';
 import { toast } from '@/components/ui/use-toast';
 import { supabase } from '@/integrations/supabase/client';
 
+interface PatientFolder {
+  id: string;
+  name: string;
+}
+
+interface CalendarEvent {
+  start: string;
+  description: string;
+  attachments?: string;
+}
 
 const WhatsAppMe = () => {
   const [phone, setPhone] = useState('');
   const [isProcessing, setIsProcessing] = useState(false);
-  const [patientFolders, setPatientFolders] = useState<any[]>([]);
-  const [calendarEvents, setCalendarEvents] = useState<any[]>([]);
+  const [patientFolders, setPatientFolders] = useState<PatientFolder[]>([]);
+  const [calendarEvents, setCalendarEvents] = useState<CalendarEvent[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
   const formatPhoneNumber = (input: string) => {
@@ -86,7 +96,7 @@ const WhatsAppMe = () => {
         address = "%2F";
     }
     
-    const finalUrl = (window as any).AndroidClipboard ? `whatsapp://send?phone=91${formattedPhone}&text=${address}` : `https://wa.me/91${formattedPhone}?text=${address}`;
+    const finalUrl = (window as { AndroidClipboard?: unknown }).AndroidClipboard ? `whatsapp://send?phone=91${formattedPhone}&text=${address}` : `https://wa.me/91${formattedPhone}?text=${address}`;
     window.location.href = finalUrl;
   };
 
@@ -105,10 +115,10 @@ const WhatsAppMe = () => {
     let address;
     switch (e) {
       case 1:
-        address = (window as any).AndroidClipboard ? `whatsapp://send?phone=917093551714&text=${formattedPhone}` : `https://wa.me/917093551714?text=${formattedPhone}`;
+        address = (window as { AndroidClipboard?: unknown }).AndroidClipboard ? `whatsapp://send?phone=917093551714&text=${formattedPhone}` : `https://wa.me/917093551714?text=${formattedPhone}`;
         break;
       case 2:
-        address = (window as any).AndroidClipboard ? `whatsapp://send?phone=919652377616&text=${formattedPhone}` : `https://wa.me/919652377616?text=${formattedPhone}`;        
+        address = (window as { AndroidClipboard?: unknown }).AndroidClipboard ? `whatsapp://send?phone=919652377616&text=${formattedPhone}` : `https://wa.me/919652377616?text=${formattedPhone}`;
         break;
       default:
         address = "%2F";
@@ -134,10 +144,11 @@ const WhatsAppMe = () => {
 
   const handlePasteClick = async () => {
     setIsProcessing(true);
-    var text;
+    let text;
     try {
-      if ((window as any).AndroidClipboard && (window as any).AndroidClipboard.getClipboardText) { 
-        text = (window as any).AndroidClipboard.getClipboardText();
+      const clipboard = (window as { AndroidClipboard?: { getClipboardText: () => string } }).AndroidClipboard;
+      if (clipboard && clipboard.getClipboardText) {
+        text = clipboard.getClipboardText();
       } else {
         text = await navigator.clipboard.readText();
       }
@@ -212,18 +223,21 @@ const WhatsAppMe = () => {
         {patientFolders.length > 0 && (
           <div className="space-y-2">
             <h3 className="text-sm font-medium text-gray-700 flex items-center gap-2">
-              <Link className="w-4 h-4" /> Patient Records
+              <Folder className="w-4 h-4" /> Patient Records
             </h3>
-            <div className="space-y-1">
+            <div className="space-y-2">
               {patientFolders.map(folder => (
-                <a
-                  key={folder.id}
-                  href={`https://drive.google.com/drive/folders/${folder.id}`}
-                  target="_blank"
-                  className="text-blue-600 hover:underline"
-                >
-                  {folder.name}
-                </a>
+                <Card key={folder.id} className="p-4">
+                  <a
+                    href={`https://drive.google.com/drive/folders/${folder.id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:underline flex items-center gap-2"
+                  >
+                    <Link className="w-4 h-4" />
+                    {folder.name}
+                  </a>
+                </Card>
               ))}
             </div>
           </div>
@@ -234,15 +248,27 @@ const WhatsAppMe = () => {
             <h3 className="text-sm font-medium text-gray-700 flex items-center gap-2">
               <Calendar className="w-4 h-4" /> Calendar Events
             </h3>
-            <ul className="space-y-1 list-disc list-inside">
+            <div className="space-y-4">
               {calendarEvents.map(event => (
-                <li key={event.id}>
-                  {event.summary} ({new Date(event.start).toLocaleString()})
-                  {event.description}
-                  {event?.attachments}
-                </li>
+                <Card key={event.start} className="p-4">
+                  <p className="font-semibold">{new Date(event.start).toLocaleString()}</p>
+                  <div className="text-sm mt-2" dangerouslySetInnerHTML={{ __html: event.description.replace(/\n/g, '<br />') }} />
+                  {event.attachments && (
+                    <div className="mt-2">
+                      <a
+                        href={event.attachments}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 hover:underline flex items-center gap-1"
+                      >
+                        <Link className="w-4 h-4" />
+                        View Attachment
+                      </a>
+                    </div>
+                  )}
+                </Card>
               ))}
-            </ul>
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
This commit updates the WhatsAppMe.tsx page to correctly render data for patient folders and calendar events as returned from the backend.

- Adds TypeScript interfaces for `PatientFolder` and `CalendarEvent` for type safety.
- Styles both `patientFolders` and `calendarEvents` using Card components for a consistent look and feel.
- Handles rendering of HTML content within the event description.
- Fixes various linting errors in the file, improving overall code quality.