### PR TITLE
fix: Add page break on horizontal rule for PDF downloads

### DIFF
--- a/src/lib/pdfUtils.ts
+++ b/src/lib/pdfUtils.ts
@@ -9,7 +9,8 @@ export const generatePdf = (htmlContent: string, filename: string) => {
     filename:     `${filename}.pdf`,
     image:        { type: 'jpeg', quality: 0.98 },
     html2canvas:  { scale: 2, useCORS: true },
-    jsPDF:        { unit: 'in', format: 'letter', orientation: 'portrait' }
+    jsPDF:        { unit: 'in', format: 'letter', orientation: 'portrait' },
+    pagebreak:    { mode: 'avoid-all', after: 'hr' }
   };
 
   // @ts-expect-error html2pdf.js does not have official type definitions


### PR DESCRIPTION
This commit updates the PDF generation utility to correctly handle page breaks. The `html2pdf.js` options have been configured to force a new page after every horizontal rule (`<hr>`) in the guide's content, ensuring better formatting for downloaded PDFs.