### PR TITLE
fix: Prevent images from splitting across pages in PDF

### DIFF
--- a/src/lib/pdfUtils.ts
+++ b/src/lib/pdfUtils.ts
@@ -10,7 +10,7 @@ export const generatePdf = (htmlContent: string, filename: string) => {
     image:        { type: 'jpeg', quality: 0.98 },
     html2canvas:  { scale: 2, useCORS: true },
     jsPDF:        { unit: 'in', format: 'letter', orientation: 'portrait' },
-    pagebreak:    { mode: 'avoid-all', after: 'hr' }
+    pagebreak:    { mode: 'avoid-all', after: 'hr', avoid: 'img' }
   };
 
   // @ts-expect-error html2pdf.js does not have official type definitions


### PR DESCRIPTION
This commit improves the PDF download functionality by preventing images from being split across two pages. The `html2pdf.js` options have been updated with `avoid: 'img'` in the `pagebreak` configuration to ensure images are kept intact during page breaking.