### PR TITLE
fix: Improve hr spacing in PDF downloads

### DIFF
--- a/src/lib/pdfUtils.ts
+++ b/src/lib/pdfUtils.ts
@@ -2,7 +2,17 @@ import html2pdf from 'html2pdf.js';
 
 export const generatePdf = (htmlContent: string, filename: string) => {
   const element = document.createElement('div');
-  element.innerHTML = htmlContent;
+  const styledHtmlContent = `
+    <style>
+      hr {
+        margin-top: 25px;
+        margin-bottom: 25px;
+        border-color: #ccc;
+      }
+    </style>
+    ${htmlContent}
+  `;
+  element.innerHTML = styledHtmlContent;
 
   const opt = {
     margin:       1,
@@ -10,7 +20,7 @@ export const generatePdf = (htmlContent: string, filename: string) => {
     image:        { type: 'jpeg', quality: 0.98 },
     html2canvas:  { scale: 2, useCORS: true },
     jsPDF:        { unit: 'in', format: 'letter', orientation: 'portrait' },
-    pagebreak:    { mode: 'avoid-all', after: 'hr', avoid: 'img' }
+    pagebreak:    { mode: 'avoid-all', avoid: 'img' }
   };
 
   // @ts-expect-error html2pdf.js does not have official type definitions


### PR DESCRIPTION
This commit updates the PDF generation utility. It removes the forced page break after horizontal rules and instead adds vertical margins via CSS to ensure adequate spacing around them in the downloaded PDF.