### PR TITLE
fix: Resolve crash on guide creation page

### DIFF
--- a/src/pages/CreateGuidePage.tsx
+++ b/src/pages/CreateGuidePage.tsx
@@ -45,7 +45,6 @@ const CreateGuidePage = () => {
       const guideToInsert = {
         ...guideData,
         category_id: categoryId,
-        download_count: 0, // Add a default value for download_count
         last_updated: new Date().toISOString(), // Add a default value for last_updated
       };
 


### PR DESCRIPTION
This commit fixes a bug that caused the application to crash when creating a new guide. The `handleSubmit` function in `CreateGuidePage.tsx` was attempting to insert a value for the `download_count` column, which no longer exists in the `guides` table. This property has been removed from the data insertion object to align with the current database schema.