### PR TITLE
fix: Resolve i18n not defined crash on guides page

### DIFF
--- a/src/pages/PatientGuidesPage.tsx
+++ b/src/pages/PatientGuidesPage.tsx
@@ -36,7 +36,7 @@ export interface Guide {
 }
 
 const PatientGuidesPage = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [guides, setGuides] = useState<Guide[]>([]);
   const [categories, setCategories] = useState<GuideCategory[]>([]);
   const [selectedCategory, setSelectedCategory] = useState<number | null>(null);


### PR DESCRIPTION
This commit fixes a bug that caused the `PatientGuidesPage` to crash with a "i18n is not defined" error. The `useTranslation` hook was not correctly destructuring the `i18n` object, which is now resolved.