### PR TITLE
feat: Update share function and make RichTextEditor sticky

### DIFF
--- a/src/components/RichTextEditor.tsx
+++ b/src/components/RichTextEditor.tsx
@@ -99,7 +99,7 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({ content, onChange }) =>
 
   return (
     <div className="border rounded-md">
-      <div className="p-2 border-b flex items-center flex-wrap gap-1">
+      <div className="p-2 border-b flex items-center flex-wrap gap-1 sticky top-0 bg-background z-10">
         <Button
           onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
           variant={editor.isActive('heading', { level: 2 }) ? 'secondary' : 'ghost'}

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -45,8 +45,8 @@ const BlogPostPage = () => {
     : baseUrl;
     
     const shareData = {
-      title: post.title,
-      text: `Check out this article from OrthoLife: ${post.title}`,
+      title: translatedPost?.title || post.title,
+      text: `Check out this article from OrthoLife: ${translatedPost?.title || post.title}`,
       url: shareUrl,
     };
     try {

--- a/src/pages/PatientGuidePage.tsx
+++ b/src/pages/PatientGuidePage.tsx
@@ -79,16 +79,21 @@ const PatientGuidePage = () => {
   }, [guideId, i18n.language]);
 
     const handleShare = async () => {
+    const baseUrl = `${window.location.origin}${window.location.pathname}`;
+    const shareUrl = i18n.language && i18n.language !== 'en'
+      ? `${baseUrl}?lang=${i18n.language}`
+      : baseUrl;
+
     const shareData = {
-      title: guide.title,
-      text: `Check out this patient guide from OrthoLife: ${guide.title}`,
-      url: window.location.href,
+      title: translatedGuide?.title || guide.title,
+      text: `Check out this patient guide from OrthoLife: ${translatedGuide?.title || guide.title}`,
+      url: shareUrl,
     };
     try {
       if (navigator.share && guide) {
         await navigator.share(shareData);
       } else {
-        await navigator.clipboard.writeText(window.location.href);
+        await navigator.clipboard.writeText(shareUrl);
         toast({
           title: "Link Copied!",
           description: "The guide link has been copied to your clipboard.",


### PR DESCRIPTION
- Updated the share function in `BlogPostPage` and `PatientGuidePage` to use the translated title and content when available.
- The share URL now includes the language parameter.
- Made the `RichTextEditor`'s toolbar sticky to improve user experience.