### PR TITLE
feat: Implement URL parameter handling for search and pricing

### DIFF
--- a/src/pages/PharmacyPage.tsx
+++ b/src/pages/PharmacyPage.tsx
@@ -77,6 +77,11 @@ const PharmacyPage = () => {
   };
 
   useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const query = params.get('q');
+    if (query) {
+      setSearchTerm(query);
+    }
     fetchMedicines();
   }, []);
 


### PR DESCRIPTION
This commit implements two new features:

1.  The `q` URL parameter is now used to populate the search box on the diagnostics and pharmacy pages. This allows users to share links with pre-filled search queries.

2.  The pricing logic on the diagnostics page has been updated to support a `code=off` URL parameter. When this parameter is not present, the `marketPrice` is displayed. When it is present, the original `price` is displayed.