### PR TITLE
fix: Adjust sticky positioning to prevent overlap

### DIFF
--- a/src/components/BlogPostForm.tsx
+++ b/src/components/BlogPostForm.tsx
@@ -95,7 +95,7 @@ const BlogPostForm: React.FC<BlogPostFormProps> = ({ initialData, translations, 
     <Form {...form}>
       <form onSubmit={form.handleSubmit(handleFormSubmit)} className="space-y-8">
         <Tabs defaultValue="english" className="w-full">
-          <TabsList className="grid w-full grid-cols-2 sticky top-16 z-10 bg-background">
+          <TabsList className="grid w-full grid-cols-2 sticky top-16 z-20 bg-background">
             <TabsTrigger value="english">English</TabsTrigger>
             <TabsTrigger value="telugu">Telugu</TabsTrigger>
           </TabsList>

--- a/src/components/GuidePostForm.tsx
+++ b/src/components/GuidePostForm.tsx
@@ -97,7 +97,7 @@ const GuidePostForm: React.FC<GuidePostFormProps> = ({ initialData, translations
     <Form {...form}>
       <form onSubmit={form.handleSubmit(handleFormSubmit)} className="space-y-8">
         <Tabs defaultValue="english" className="w-full">
-          <TabsList className="grid w-full grid-cols-2 sticky top-16 z-10 bg-background">
+          <TabsList className="grid w-full grid-cols-2 sticky top-16 z-20 bg-background">
             <TabsTrigger value="english">English</TabsTrigger>
             <TabsTrigger value="telugu">Telugu</TabsTrigger>
           </TabsList>

--- a/src/components/RichTextEditor.tsx
+++ b/src/components/RichTextEditor.tsx
@@ -99,7 +99,7 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({ content, onChange }) =>
 
   return (
     <div className="border rounded-md">
-      <div className="p-2 border-b flex items-center flex-wrap gap-1 sticky top-20 bg-background z-40">
+      <div className="p-2 border-b flex items-center flex-wrap gap-1 sticky top-[104px] bg-background z-40">
         <Button
           onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
           variant={editor.isActive('heading', { level: 2 }) ? 'secondary' : 'ghost'}


### PR DESCRIPTION
The sticky language switching tabs were being hidden by the sticky text editor toolbar. This change adjusts the `top` positioning of the text editor toolbar and the `z-index` of the language switcher to ensure they are both visible and correctly layered when scrolling.