### PR TITLE
feat: Re-implement image features incrementally for debugging

### DIFF
--- a/src/components/CustomImage.ts
+++ b/src/components/CustomImage.ts
@@ -13,11 +13,14 @@ export const CustomImage = Image.extend({
       align: {
         default: 'center',
       },
+      display: {
+        default: 'block',
+      }
     };
   },
 
   renderHTML({ HTMLAttributes }) {
-    const { align, width } = HTMLAttributes;
+    const { align, width, display } = HTMLAttributes;
 
     const style: { [key: string]: string } = {};
     if (align === 'left') style['margin-right'] = 'auto';
@@ -27,8 +30,7 @@ export const CustomImage = Image.extend({
       style['margin-right'] = 'auto';
     }
     
-    // a block element is required for margin auto to work
-    style['display'] = 'block';
+    style['display'] = display;
     
     if (width) {
         style['width'] = width;

--- a/src/components/RichTextEditor.tsx
+++ b/src/components/RichTextEditor.tsx
@@ -29,6 +29,9 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({ content, onChange }) =>
           levels: [2, 3],
         },
       }),
+      BubbleMenu.configure({
+        pluginKey: 'imageBubbleMenu',
+      }),
       Underline,
       CustomImage,
       TextStyle,
@@ -245,6 +248,13 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({ content, onChange }) =>
         />
       </div>
       <EditorContent editor={editor} />
+      {editor && <BubbleMenu editor={editor} tippyOptions={{ duration: 100 }} pluginKey="imageBubbleMenu" shouldShow={({ editor, from, to }) => editor.isActive('custom-image')}>
+        <div className="p-2 bg-background border rounded-md shadow-lg flex items-center gap-2">
+          <Button onClick={() => editor.chain().focus().setImage({ align: 'left' }).run()} variant={editor.isActive('custom-image', { align: 'left' }) ? 'secondary' : 'ghost'} size="sm" type="button" title="Align Left">
+            <AlignLeft className="h-4 w-4" />
+          </Button>
+        </div>
+      </BubbleMenu>}
       <input
         type="file"
         ref={fileInputRef}


### PR DESCRIPTION
This commit re-introduces the image alignment and resizing features in an incremental way to help debug a runtime error.

- The `CustomImage` extension has been updated to support `width`, `align`, and `display` attributes.
- A `BubbleMenu` for images has been added back to the `RichTextEditor`, but it currently only contains a single button ("Align Left").

This partial implementation will be tested to confirm if the basic functionality works without causing the previous runtime error.