### PR TITLE
fix: Correct BubbleMenu imports for debugging

### DIFF
--- a/src/components/RichTextEditor.tsx
+++ b/src/components/RichTextEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
-import { useEditor, EditorContent } from '@tiptap/react';
-import { BubbleMenu } from '@tiptap/extension-bubble-menu';
+import { useEditor, EditorContent, BubbleMenu as BubbleMenuComponent } from '@tiptap/react';
+import BubbleMenu from '@tiptap/extension-bubble-menu';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
 import Link from '@tiptap/extension-link';
@@ -248,13 +248,13 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({ content, onChange }) =>
         />
       </div>
       <EditorContent editor={editor} />
-      {editor && <BubbleMenu editor={editor} tippyOptions={{ duration: 100 }} pluginKey="imageBubbleMenu" shouldShow={({ editor, from, to }) => editor.isActive('custom-image')}>
+      {editor && <BubbleMenuComponent editor={editor} tippyOptions={{ duration: 100 }} pluginKey="imageBubbleMenu" shouldShow={({ editor, from, to }) => editor.isActive('custom-image')}>
         <div className="p-2 bg-background border rounded-md shadow-lg flex items-center gap-2">
           <Button onClick={() => editor.chain().focus().setImage({ align: 'left' }).run()} variant={editor.isActive('custom-image', { align: 'left' }) ? 'secondary' : 'ghost'} size="sm" type="button" title="Align Left">
             <AlignLeft className="h-4 w-4" />
           </Button>
         </div>
-      </BubbleMenu>}
+      </BubbleMenuComponent>}
       <input
         type="file"
         ref={fileInputRef}


### PR DESCRIPTION
This commit corrects the import statements for the Tiptap BubbleMenu extension and component in `RichTextEditor.tsx`. This is an attempt to fix the runtime error "Element type is invalid".

- The `BubbleMenu` component is now imported from `@tiptap/react` with an alias.
- The `BubbleMenu` extension is now imported from `@tiptap/extension-bubble-menu`.

The `BubbleMenu` still only contains a single button for "Align Left". This is intentional for debugging. If this fix resolves the runtime error, the remaining controls will be added in a subsequent commit.