### PR TITLE
feat: Enhance RichTextEditor with table and image options

### DIFF
--- a/src/components/RichTextEditor.tsx
+++ b/src/components/RichTextEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
-import { useEditor, EditorContent, BubbleMenu as BubbleMenuComponent } from '@tiptap/react';
-import BubbleMenu from '@tiptap/extension-bubble-menu';
+import { useEditor, EditorContent } from '@tiptap/react';
+import BubbleMenuExtension, { BubbleMenu } from '@tiptap/extension-bubble-menu';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
 import Link from '@tiptap/extension-link';
@@ -29,7 +29,7 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({ content, onChange }) =>
           levels: [2, 3],
         },
       }),
-      BubbleMenu.configure({
+      BubbleMenuExtension.configure({
         pluginKey: 'imageBubbleMenu',
       }),
       Underline,
@@ -248,13 +248,30 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({ content, onChange }) =>
         />
       </div>
       <EditorContent editor={editor} />
-      {editor && <BubbleMenuComponent editor={editor} tippyOptions={{ duration: 100 }} pluginKey="imageBubbleMenu" shouldShow={({ editor, from, to }) => editor.isActive('custom-image')}>
+      {editor && <BubbleMenu editor={editor} tippyOptions={{ duration: 100 }} pluginKey="imageBubbleMenu" shouldShow={({ editor, from, to }) => editor.isActive('custom-image')}>
         <div className="p-2 bg-background border rounded-md shadow-lg flex items-center gap-2">
           <Button onClick={() => editor.chain().focus().setImage({ align: 'left' }).run()} variant={editor.isActive('custom-image', { align: 'left' }) ? 'secondary' : 'ghost'} size="sm" type="button" title="Align Left">
             <AlignLeft className="h-4 w-4" />
           </Button>
+          <Button onClick={() => editor.chain().focus().setImage({ align: 'center' }).run()} variant={editor.isActive('custom-image', { align: 'center' }) ? 'secondary' : 'ghost'} size="sm" type="button" title="Align Center">
+            <AlignCenter className="h-4 w-4" />
+          </Button>
+          <Button onClick={() => editor.chain().focus().setImage({ align: 'right' }).run()} variant={editor.isActive('custom-image', { align: 'right' }) ? 'secondary' : 'ghost'} size="sm" type="button" title="Align Right">
+            <AlignRight className="h-4 w-4" />
+          </Button>
+          <Button onClick={() => editor.chain().focus().setImage({ display: editor.getAttributes('custom-image').display === 'block' ? 'inline-block' : 'block' }).run()} variant={editor.isActive('custom-image', { display: 'inline-block' }) ? 'secondary' : 'ghost'} size="sm" type="button" title="Toggle Display">
+            <Pilcrow className="h-4 w-4" />
+          </Button>
+          <input
+            type="range"
+            min="25"
+            max="100"
+            value={parseInt(editor.getAttributes('custom-image').width?.replace('%', '')) || 100}
+            onChange={(e) => editor.chain().focus().setImage({ width: `${e.target.value}%` }).run()}
+            className="w-24"
+          />
         </div>
-      </BubbleMenuComponent>}
+      </BubbleMenu>}
       <input
         type="file"
         ref={fileInputRef}


### PR DESCRIPTION
This commit introduces several enhancements to the RichTextEditor, allows empty "What's Next" fields, and internationalizes the "What's Next for You?" heading.

RichTextEditor enhancements:
- **Table Insertion:** Users can now insert and manipulate tables within the rich text editor, including adding and removing rows and columns.
- **Image Resizing and Alignment:** A bubble menu has been added for images, allowing users to align them (left, center, right), toggle between block and inline display, and resize them using a slider.

Form enhancements:
- **Empty "What's Next" Fields:** The blog and guide post forms now correctly handle empty "What's Next" fields by saving an empty string.

Internationalization:
- **"What's Next for You?" Heading:** The heading in the `NextSteps` component is now translated based on the selected language.

This commit also includes fixes for previous build and runtime errors related to Tiptap extension imports.