### PR TITLE
feat: Enhance RichTextEditor with full table and image support

### DIFF
--- a/src/components/RichTextEditor.tsx
+++ b/src/components/RichTextEditor.tsx
@@ -251,16 +251,53 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({ content, onChange }) =>
       <EditorContent editor={editor} />
       {editor && <BubbleMenu editor={editor} tippyOptions={{ duration: 100 }} pluginKey="imageBubbleMenu" shouldShow={({ editor, from, to }) => editor.isActive('custom-image')}>
         <div className="p-2 bg-background border rounded-md shadow-lg flex items-center gap-2">
-          <Button onClick={() => editor.chain().focus().setImage({ align: 'left' }).run()} variant={editor.isActive('custom-image', { align: 'left' }) ? 'secondary' : 'ghost'} size="sm" type="button" title="Align Left">
+          <Button
+            onClick={() => {
+              const currentAttributes = editor.getAttributes('custom-image');
+              editor.chain().focus().setImage({ ...currentAttributes, align: 'left' }).run();
+            }}
+            variant={editor.isActive('custom-image', { align: 'left' }) ? 'secondary' : 'ghost'}
+            size="sm"
+            type="button"
+            title="Align Left"
+          >
             <AlignLeft className="h-4 w-4" />
           </Button>
-          <Button onClick={() => editor.chain().focus().setImage({ align: 'center' }).run()} variant={editor.isActive('custom-image', { align: 'center' }) ? 'secondary' : 'ghost'} size="sm" type="button" title="Align Center">
+          <Button
+            onClick={() => {
+              const currentAttributes = editor.getAttributes('custom-image');
+              editor.chain().focus().setImage({ ...currentAttributes, align: 'center' }).run();
+            }}
+            variant={editor.isActive('custom-image', { align: 'center' }) ? 'secondary' : 'ghost'}
+            size="sm"
+            type="button"
+            title="Align Center"
+          >
             <AlignCenter className="h-4 w-4" />
           </Button>
-          <Button onClick={() => editor.chain().focus().setImage({ align: 'right' }).run()} variant={editor.isActive('custom-image', { align: 'right' }) ? 'secondary' : 'ghost'} size="sm" type="button" title="Align Right">
+          <Button
+            onClick={() => {
+              const currentAttributes = editor.getAttributes('custom-image');
+              editor.chain().focus().setImage({ ...currentAttributes, align: 'right' }).run();
+            }}
+            variant={editor.isActive('custom-image', { align: 'right' }) ? 'secondary' : 'ghost'}
+            size="sm"
+            type="button"
+            title="Align Right"
+          >
             <AlignRight className="h-4 w-4" />
           </Button>
-          <Button onClick={() => editor.chain().focus().setImage({ display: editor.getAttributes('custom-image').display === 'block' ? 'inline-block' : 'block' }).run()} variant={editor.isActive('custom-image', { display: 'inline-block' }) ? 'secondary' : 'ghost'} size="sm" type="button" title="Toggle Display">
+          <Button
+            onClick={() => {
+              const currentAttributes = editor.getAttributes('custom-image');
+              const newDisplay = currentAttributes.display === 'block' ? 'inline-block' : 'block';
+              editor.chain().focus().setImage({ ...currentAttributes, display: newDisplay }).run();
+            }}
+            variant={editor.isActive('custom-image', { display: 'inline-block' }) ? 'secondary' : 'ghost'}
+            size="sm"
+            type="button"
+            title="Toggle Display"
+          >
             <Pilcrow className="h-4 w-4" />
           </Button>
           <input
@@ -268,7 +305,10 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({ content, onChange }) =>
             min="25"
             max="100"
             value={parseInt(editor.getAttributes('custom-image').width?.replace('%', '')) || 100}
-            onChange={(e) => editor.chain().focus().setImage({ width: `${e.target.value}%` }).run()}
+            onChange={(e) => {
+              const currentAttributes = editor.getAttributes('custom-image');
+              editor.chain().focus().setImage({ ...currentAttributes, width: `${e.target.value}%` }).run();
+            }}
             className="w-24"
           />
         </div>


### PR DESCRIPTION
This commit delivers a comprehensive set of enhancements to the RichTextEditor, allows empty "What's Next" fields, and internationalizes the "What's Next for You?" heading.

RichTextEditor Enhancements:
- **Table Insertion:** Users can now insert, modify (add/remove rows/columns), and delete tables.
- **Image Manipulation:** A BubbleMenu now appears on image selection, providing controls for:
  - Alignment (left, center, right).
  - Resizing via a percentage-based slider.
  - Toggling between block and inline display to support inline images.

Form Enhancements:
- **Empty "What's Next" Fields:** The blog and guide post forms now correctly handle empty "What's Next" fields by saving an empty string, preventing validation issues with empty paragraph tags.

Internationalization:
- **"What's Next for You?" Heading:** The heading in the `NextSteps` component is now translated based on the selected language.

Fixes:
- **BubbleMenu Import:** Resolves a persistent build and runtime error by correcting the import path for the BubbleMenu component to `@tiptap/react/menus`.
- **Image Disappearing Bug:** Fixes an issue where using the image manipulation controls would cause the image to disappear by ensuring the `src` attribute is preserved on update.