### PR TITLE
fix: Make tables in prose content responsive

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -51,3 +51,10 @@
     @apply scroll-smooth;
   }
 }
+
+/* Make tables in prose content responsive */
+.prose table {
+  width: 100%;
+  overflow-x: auto;
+  display: block;
+}


### PR DESCRIPTION
This commit adds a CSS rule to make tables generated by the RichTextEditor responsive on mobile devices.

- Tables within the `.prose` container will now scroll horizontally if their content is too wide for the screen.
- This prevents the tables from overflowing and breaking the page layout on smaller viewports.