### PR TITLE
feat: Update patient guide routes to /guides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,10 @@
         "@tiptap/extension-color": "^3.2.0",
         "@tiptap/extension-image": "^3.2.0",
         "@tiptap/extension-link": "^3.2.0",
+        "@tiptap/extension-table": "^3.3.0",
+        "@tiptap/extension-table-cell": "^3.3.0",
+        "@tiptap/extension-table-header": "^3.3.0",
+        "@tiptap/extension-table-row": "^3.3.0",
         "@tiptap/extension-text-style": "^3.2.0",
         "@tiptap/extension-underline": "^3.2.0",
         "@tiptap/react": "^3.2.0",
@@ -88,6 +92,9 @@
         "postcss": "^8.4.47",
         "supabase": "^2.39.2",
         "tailwindcss": "^3.4.11",
+        "ts-node": "^10.9.2",
+        "tsconfig-paths": "^4.2.0",
+        "tsx": "^4.20.5",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.1",
         "vite": "^5.4.1"
@@ -162,6 +169,30 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2982,16 +3013,16 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.2.0.tgz",
-      "integrity": "sha512-1Dk1AIwzJejcyi4FOEcKoBSLMkHMfxeDiQ0daG51eS1IZ1ZSF+Xlhg9OD5sAjbUTGQjK1HfU6kGwS9wJcR/9ZQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.3.0.tgz",
+      "integrity": "sha512-YAmFITHzgp/hafA7Ety1qMo4Tl5e5b2+06LaiB9k3rAI7gfO6AXCwhXUqm3fCScmBfMMvMycq9IOIiHk946IzA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.2.0"
+        "@tiptap/pm": "^3.3.0"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
@@ -3307,6 +3338,59 @@
         "@tiptap/core": "^3.2.0"
       }
     },
+    "node_modules/@tiptap/extension-table": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.3.0.tgz",
+      "integrity": "sha512-8Etfm5voWGUM4sHv/OXj4yu8DFosGvATbC2Qf/TvksEdo6RLddyK/ZTnCz/EoL1+1pLcktW5xOqdQnmaqWZMzA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.3.0",
+        "@tiptap/pm": "^3.3.0"
+      }
+    },
+    "node_modules/@tiptap/extension-table-cell": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-cell/-/extension-table-cell-3.3.0.tgz",
+      "integrity": "sha512-AcL/is/zNwN6ARdjv+leE/wit3d0yp15bR0YFQcWaZ+jGBUOHTuEkLgSRI5Yv4E6g3/0x0dGrwhnRjBM6u0kKw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-table": "^3.3.0"
+      }
+    },
+    "node_modules/@tiptap/extension-table-header": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-header/-/extension-table-header-3.3.0.tgz",
+      "integrity": "sha512-d3LJKf2UnkOK1B0qqbwY2ODXuXl3YPmpC4S5AxBOCEUT0n6DZ/J1k3nVCtpRHoWUXEoEs9tg9UOqCowSmrClRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-table": "^3.3.0"
+      }
+    },
+    "node_modules/@tiptap/extension-table-row": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-table-row/-/extension-table-row-3.3.0.tgz",
+      "integrity": "sha512-mr4aY+oze9ahc0vPQkrYvJ5d4Sa92nofM+UK9i9GjJRHyGuMKfD73s29d6SrtahPUQ5rYo/+sTmTf9QppHYEGA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-table": "^3.3.0"
+      }
+    },
     "node_modules/@tiptap/extension-text": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.2.0.tgz",
@@ -3361,9 +3445,9 @@
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.2.0.tgz",
-      "integrity": "sha512-2UTlVts1Q7snQaUlxUtXfwEndNgcBcEIf74f1aEzcLzJRwBRRexCS6M0n+F50IifoB0OVBZENMBv1X/YXIPGPA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.3.0.tgz",
+      "integrity": "sha512-uKsysdjP5kQbQRQN8YinN5lr71TVgsHKhxgkq/psXZzNoUh2fPoNpzkhZTaondgr0IXFwzYX+DA5cLkzu4ig/A==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
@@ -3450,6 +3534,34 @@
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.1",
@@ -3898,7 +4010,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -3915,6 +4027,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -4392,6 +4517,13 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
@@ -4631,6 +4763,16 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -5215,6 +5357,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -5601,6 +5756,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/jspdf": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.1.tgz",
@@ -5774,6 +5942,13 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "devOptional": true,
+      "license": "ISC"
+    },
     "node_modules/markdown-it": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
@@ -5830,6 +6005,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -6944,6 +7129,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -7211,6 +7406,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/strip-json-comments": {
@@ -7482,11 +7687,97 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz",
+      "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7658,6 +7949,13 @@
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/vaul": {
       "version": "0.9.9",
@@ -8393,6 +8691,16 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "npm run sitemap && vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "sitemap": "tsx src/lib/sitemap-generator.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -95,6 +96,9 @@
     "postcss": "^8.4.47",
     "supabase": "^2.39.2",
     "tailwindcss": "^3.4.11",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
+    "tsx": "^4.20.5",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -12,3 +12,5 @@ Allow: /
 
 User-agent: *
 Allow: /
+
+Sitemap: https://ortho.life/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+
+        <url>
+          <loc>https://ortho.life/</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>weekly</changefreq>
+          <priority>0.8</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/appointment</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>weekly</changefreq>
+          <priority>0.8</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/pharmacy</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>weekly</changefreq>
+          <priority>0.8</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/diagnostics</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>weekly</changefreq>
+          <priority>0.8</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/blog</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>weekly</changefreq>
+          <priority>0.8</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/guides</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>weekly</changefreq>
+          <priority>0.8</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/faqs</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>weekly</changefreq>
+          <priority>0.8</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/resources</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>weekly</changefreq>
+          <priority>0.8</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/legal</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>weekly</changefreq>
+          <priority>0.8</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/upload-prescription</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>weekly</changefreq>
+          <priority>0.8</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/track-test-results</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>weekly</changefreq>
+          <priority>0.8</priority>
+        </url>
+
+
+        <url>
+          <loc>https://ortho.life/blog/4</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>daily</changefreq>
+          <priority>0.9</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/blog/1</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>daily</changefreq>
+          <priority>0.9</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/blog/2</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>daily</changefreq>
+          <priority>0.9</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/blog/3</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>daily</changefreq>
+          <priority>0.9</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/blog/9</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>daily</changefreq>
+          <priority>0.9</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/blog/7</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>daily</changefreq>
+          <priority>0.9</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/blog/5</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>daily</changefreq>
+          <priority>0.9</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/blog/11</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>daily</changefreq>
+          <priority>0.9</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/blog/8</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>daily</changefreq>
+          <priority>0.9</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/blog/10</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>daily</changefreq>
+          <priority>0.9</priority>
+        </url>
+
+
+        <url>
+          <loc>https://ortho.life/guides/5</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>daily</changefreq>
+          <priority>0.9</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/guides/2</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>daily</changefreq>
+          <priority>0.9</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/guides/4</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>daily</changefreq>
+          <priority>0.9</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/guides/1</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>daily</changefreq>
+          <priority>0.9</priority>
+        </url>
+
+        <url>
+          <loc>https://ortho.life/guides/3</loc>
+          <lastmod>2025-08-30T15:31:44.240Z</lastmod>
+          <changefreq>daily</changefreq>
+          <priority>0.9</priority>
+        </url>
+
+    </urlset>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,10 +58,10 @@ const App = () => (
               <Route path="/blog/new" element={<CreatePostPage />} />
               <Route path="/blog/:postId" element={<BlogPostPage />} />
               <Route path="/blog/:postId/edit" element={<EditPostPage />} />
-              <Route path="/patient-guides" element={<PatientGuidesPage />} />
-              <Route path="/patient-guides/new" element={<CreateGuidePage />} />
-              <Route path="/patient-guides/:guideId" element={<PatientGuidePage />} />
-              <Route path="/patient-guides/:guideId/edit" element={<EditGuidePage />} />
+              <Route path="/guides" element={<PatientGuidesPage />} />
+              <Route path="/guides/new" element={<CreateGuidePage />} />
+              <Route path="/guides/:guideId" element={<PatientGuidePage />} />
+              <Route path="/guides/:guideId/edit" element={<EditGuidePage />} />
               <Route path="/faqs" element={<FAQPage />} />
               <Route path="/resources" element={<ResourcesPage />} />
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -183,7 +183,7 @@ const Header = () => {
                       </NavigationMenuLink>
                       <NavigationMenuLink asChild>
                         <Link
-                          to={withLang("/patient-guides")}
+                          to={withLang("/guides")}
                           className={cn(
                             "block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
                           )}
@@ -285,7 +285,7 @@ const Header = () => {
                 <span className="block font-medium text-primary">Learn</span>
               </div>
               <Link to={withLang("/blog")} className="block pl-4 text-sm hover:text-primary transition-colors" onClick={() => setIsMobileMenuOpen(false)}>Blog</Link>
-              <Link to={withLang("/patient-guides")} className="block pl-4 text-sm hover:text-primary transition-colors" onClick={() => setIsMobileMenuOpen(false)}>Health Guides</Link>
+              <Link to={withLang("/guides")} className="block pl-4 text-sm hover:text-primary transition-colors" onClick={() => setIsMobileMenuOpen(false)}>Health Guides</Link>
               <Link to={withLang("/faqs")} className="block pl-4 text-sm hover:text-primary transition-colors" onClick={() => setIsMobileMenuOpen(false)}>FAQs</Link>
               <Link to={withLang("/resources")} className="block pl-4 text-sm hover:text-primary transition-colors" onClick={() => setIsMobileMenuOpen(false)}>Resources</Link>
             </div>

--- a/src/lib/sitemap-generator.ts
+++ b/src/lib/sitemap-generator.ts
@@ -1,0 +1,68 @@
+import { supabase } from '@/integrations/supabase/client';
+import * as fs from 'fs';
+
+const BASE_URL = 'https://ortho.life';
+
+const staticRoutes = [
+  '/',
+  '/appointment',
+  '/pharmacy',
+  '/diagnostics',
+  '/blog',
+  '/guides',
+  '/faqs',
+  '/resources',
+  '/legal',
+  '/upload-prescription',
+  '/track-test-results',
+];
+
+async function generateSitemap() {
+  console.log('Generating sitemap...');
+
+  const { data: posts, error: postsError } = await supabase.from('posts').select('id');
+  if (postsError) {
+    console.error('Error fetching posts:', postsError);
+    return;
+  }
+
+  const { data: guides, error: guidesError } = await supabase.from('guides').select('id');
+  if (guidesError) {
+    console.error('Error fetching guides:', guidesError);
+    return;
+  }
+
+  const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      ${staticRoutes.map(route => `
+        <url>
+          <loc>${BASE_URL}${route}</loc>
+          <lastmod>${new Date().toISOString()}</lastmod>
+          <changefreq>weekly</changefreq>
+          <priority>0.8</priority>
+        </url>
+      `).join('')}
+      ${posts?.map(({ id }) => `
+        <url>
+          <loc>${BASE_URL}/blog/${id}</loc>
+          <lastmod>${new Date().toISOString()}</lastmod>
+          <changefreq>daily</changefreq>
+          <priority>0.9</priority>
+        </url>
+      `).join('')}
+      ${guides?.map(({ id }) => `
+        <url>
+          <loc>${BASE_URL}/guides/${id}</loc>
+          <lastmod>${new Date().toISOString()}</lastmod>
+          <changefreq>daily</changefreq>
+          <priority>0.9</priority>
+        </url>
+      `).join('')}
+    </urlset>
+  `;
+
+  fs.writeFileSync('public/sitemap.xml', sitemap.trim());
+  console.log('Sitemap generated successfully!');
+}
+
+generateSitemap();

--- a/src/pages/CreateGuidePage.tsx
+++ b/src/pages/CreateGuidePage.tsx
@@ -82,7 +82,7 @@ const CreateGuidePage = () => {
         description: "Your new patient guide has been successfully created.",
       });
 
-      navigate(`/patient-guides/${newGuide.id}`);
+      navigate(`/guides/${newGuide.id}`);
 
     } catch (error) {
       console.error('Error creating guide:', error);

--- a/src/pages/EditGuidePage.tsx
+++ b/src/pages/EditGuidePage.tsx
@@ -109,7 +109,7 @@ const EditGuidePage = () => {
         title: "Guide updated!",
         description: "The patient guide has been successfully updated.",
       });
-      navigate(`/patient-guides/${guideId}`);
+      navigate(`/guides/${guideId}`);
 
     } catch (error) {
       console.error('Error updating guide:', error);

--- a/src/pages/PatientGuidePage.tsx
+++ b/src/pages/PatientGuidePage.tsx
@@ -164,7 +164,7 @@ const PatientGuidePage = () => {
                 <div className="sticky bottom-0 p-4 border-t z-10 bg-background/20 backdrop-blur-sm">        
                   <div className="flex flex-wrap justify-between items-center gap-4">
                     <Button asChild variant="outline">
-                      <Link to="/patient-guides">
+                      <Link to="/guides">
                         <ArrowLeft className="mr-2 h-4 w-4" />
                         Back to Guides
                       </Link>

--- a/src/pages/PatientGuidesPage.tsx
+++ b/src/pages/PatientGuidesPage.tsx
@@ -273,7 +273,7 @@ const PatientGuidesPage = () => {
                       </div>
                       <div className="flex gap-3">
                         <Button asChild className="flex items-center gap-2">
-                          <Link to={`/patient-guides/${guides[0].id}`}>
+                          <Link to={`/guides/${guides[0].id}`}>
                             <Eye size={16} />
                             {t('guides.readOnline')}
                           </Link>
@@ -288,7 +288,7 @@ const PatientGuidesPage = () => {
 
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                   {guides.slice(1).map((guide) => (
-                    <Link to={`/patient-guides/${guide.id}`} key={guide.id} className="group">
+                    <Link to={`/guides/${guide.id}`} key={guide.id} className="group">
                       <Card className="overflow-hidden hover:shadow-lg transition-shadow h-full flex flex-col">
                         <div className="aspect-video overflow-hidden">
                           <img
@@ -324,7 +324,7 @@ const PatientGuidesPage = () => {
                           </div>
                           <div className="flex gap-2 mt-auto">
                             <Button asChild size="sm" className="flex-1">
-                              <Link to={`/patient-guides/${guide.id}`}>
+                              <Link to={`/guides/${guide.id}`}>
                                 <Eye size={14} className="mr-1" />
                                 {t('guides.read')}
                               </Link>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,11 @@
     "allowJs": true,
     "noUnusedLocals": false,
     "strictNullChecks": false
+  },
+  "ts-node": {
+    "esm": true,
+    "compilerOptions": {
+      "module": "NodeNext"
+    }
   }
 }


### PR DESCRIPTION
This commit updates the routes for patient guides from `/patient-guides` to `/guides` for better user experience.

Changes include:
- Updating the routes in `src/App.tsx`.
- Updating all `Link` components and navigation elements to use the new routes.
- Updating the sitemap generator to reflect the new routes.
- Removing `/wa` and `/emr` routes from the sitemap as requested.