### PR TITLE
feat: Remove author and date from blogs

### DIFF
--- a/src/components/BlogPostForm.tsx
+++ b/src/components/BlogPostForm.tsx
@@ -22,7 +22,6 @@ const postFormSchema = z.object({
   title: z.string().min(1, "Title is required"),
   excerpt: z.string().min(1, "Excerpt is required"),
   content: z.string().min(1, "Content is required"),
-  author: z.string().min(1, "Author is required"),
   image_url: z.string().url("Please enter a valid URL"),
   read_time_minutes: z.coerce.number().int().positive("Must be a positive number"),
   category_name: z.string().min(1, "Category is required"),
@@ -214,19 +213,6 @@ const BlogPostForm: React.FC<BlogPostFormProps> = ({ initialData, translations, 
         </Tabs>
 
         <div className="space-y-8 pt-8 border-t">
-          <FormField
-            control={form.control}
-            name="author"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Author</FormLabel>
-                <FormControl>
-                  <Input placeholder="Enter author's name" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
           <FormField
             control={form.control}
             name="image_url"

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -5,7 +5,7 @@ import Footer from '@/components/Footer';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Calendar, User, Clock, ArrowRight } from 'lucide-react';
+import { Clock, ArrowRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { supabase } from '@/integrations/supabase/client';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -21,8 +21,6 @@ export interface Post {
   id: number;
   title: string;
   excerpt: string;
-  author: string;
-  created_at: string;
   read_time_minutes: number;
   category_id: number;
   image_url: string;
@@ -249,10 +247,6 @@ const BlogPage = () => {
                         {getTranslatedPost(featuredPost, i18n.language).excerpt}
                       </p>
                       <div className="flex items-center text-sm text-muted-foreground mb-4 flex-wrap">
-                        <User size={16} className="mr-1" />
-                        <span className="mr-4">{featuredPost.author}</span>
-                        <Calendar size={16} className="mr-1" />
-                        <span className="mr-4">{new Date(featuredPost.created_at).toLocaleDateString()}</span>
                         <Clock size={16} className="mr-1" />
                         <span>{featuredPost.read_time_minutes} min read</span>
                       </div>
@@ -291,14 +285,6 @@ const BlogPage = () => {
                             {getTranslatedPost(post, i18n.language).excerpt}
                           </CardDescription>
                         </CardHeader>
-                        <CardContent className="mt-auto">
-                          <div className="flex items-center text-sm text-muted-foreground">
-                            <User size={14} className="mr-1" />
-                            <span className="mr-3">{post.author}</span>
-                            <Calendar size={14} className="mr-1" />
-                            <span>{new Date(post.created_at).toLocaleDateString()}</span>
-                          </div>
-                        </CardContent>
                       </Card>
                     </Link>
                   ))}

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -5,7 +5,7 @@ import Footer from '@/components/Footer';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Calendar, User, Clock, Share2, ArrowLeft } from 'lucide-react';
+import { Clock, Share2, ArrowLeft } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useToast } from '@/components/ui/use-toast';
 import { supabase } from '@/integrations/supabase/client';
@@ -18,8 +18,6 @@ interface Post {
   title: string;
   content: string;
   excerpt?: string;
-  author: string;
-  created_at: string;
   read_time_minutes: number;
   image_url: string;
   categories: { name: string };
@@ -169,8 +167,6 @@ const BlogPostPage = () => {
       setMetaTag('twitter:image', post.image_url);
       
       // Set article-specific meta tags
-      setOGMetaTag('article:author', post.author);
-      setOGMetaTag('article:published_time', post.created_at);
     } else if (!loading) {
       // Reset title when post not found
       document.title = 'Post Not Found | OrthoLife';
@@ -216,14 +212,6 @@ const BlogPostPage = () => {
                     {translatedPost?.title || post.title}
                   </h1>
                   <div className="flex items-center text-muted-foreground flex-wrap">
-                    <div className="flex items-center mr-6 mb-2">
-                      <User size={16} className="mr-2" />
-                      <span>{post.author}</span>
-                    </div>
-                    <div className="flex items-center mr-6 mb-2">
-                      <Calendar size={16} className="mr-2" />
-                      <span>{new Date(post.created_at).toLocaleDateString()}</span>
-                    </div>
                     <div className="flex items-center mb-2">
                       <Clock size={16} className="mr-2" />
                       <span>{post.read_time_minutes} min read</span>

--- a/supabase/migrations/20240814074500_create_blog_tables.sql
+++ b/supabase/migrations/20240814074500_create_blog_tables.sql
@@ -11,7 +11,6 @@ CREATE TABLE posts (
     title TEXT NOT NULL,
     excerpt TEXT,
     content TEXT,
-    author TEXT,
     image_url TEXT,
     read_time_minutes INT,
     category_id BIGINT REFERENCES categories(id)
@@ -26,12 +25,11 @@ INSERT INTO categories (name) VALUES
 ('Physical Therapy');
 
 -- Insert seed data into the posts table
-INSERT INTO posts (title, excerpt, content, author, image_url, read_time_minutes, category_id) VALUES
+INSERT INTO posts (title, excerpt, content, image_url, read_time_minutes, category_id) VALUES
 (
     '5 Essential Tips for Maintaining Healthy Bones',
     'Learn about the key nutrients and exercises that keep your bones strong and healthy throughout life.',
     'Learn about the key nutrients and exercises that keep your bones strong and healthy throughout life. This includes getting enough calcium and vitamin D, engaging in weight-bearing exercises, and avoiding smoking and excessive alcohol consumption.',
-    'Dr. Sarah Wilson',
     'https://images.unsplash.com/photo-1559757148-5c350d0d3c56?w=500&h=300&fit=crop',
     5,
     (SELECT id FROM categories WHERE name = 'Bone Health')
@@ -40,7 +38,6 @@ INSERT INTO posts (title, excerpt, content, author, image_url, read_time_minutes
     'Understanding Osteoporosis: Prevention and Treatment',
     'A comprehensive guide to understanding osteoporosis, its risk factors, and modern treatment approaches.',
     'A comprehensive guide to understanding osteoporosis, its risk factors, and modern treatment approaches. We will cover the role of diet, exercise, and medication in managing this condition.',
-    'Dr. Michael Johnson',
     'https/images.unsplash.com/photo-1576091160399-112ba8d25d1f?w=500&h=300&fit=crop',
     8,
     (SELECT id FROM categories WHERE name = 'Osteoporosis')
@@ -49,7 +46,6 @@ INSERT INTO posts (title, excerpt, content, author, image_url, read_time_minutes
     'Post-Surgery Recovery: What to Expect',
     'Essential information about the recovery process after orthopedic surgery and how to optimize healing.',
     'Essential information about the recovery process after orthopedic surgery and how to optimize healing. This post will guide you through the different stages of recovery, from the hospital to your home.',
-    'Dr. Emily Davis',
     'https://images.unsplash.com/photo-1551601651-2a8555f1a136?w=500&h=300&fit=crop',
     6,
     (SELECT id FROM categories WHERE name = 'Surgery Recovery')
@@ -58,7 +54,6 @@ INSERT INTO posts (title, excerpt, content, author, image_url, read_time_minutes
     'Managing Chronic Joint Pain Naturally',
     'Discover natural methods and lifestyle changes that can help reduce chronic joint pain and inflammation.',
     'Discover natural methods and lifestyle changes that can help reduce chronic joint pain and inflammation. We will explore various techniques, from acupuncture to anti-inflammatory diets.',
-    'Dr. Robert Chen',
     'https://images.unsplash.com/photo-1594824369069-c9a3dd6e2019?w=500&h=300&fit=crop',
     7,
     (SELECT id FROM categories WHERE name = 'Pain Management')
@@ -67,7 +62,6 @@ INSERT INTO posts (title, excerpt, content, author, image_url, read_time_minutes
     'The Role of Physical Therapy in Recovery',
     'Understanding how physical therapy accelerates healing and prevents future injuries.',
     'Understanding how physical therapy accelerates healing and prevents future injuries. This post will detail the benefits of physical therapy and what to expect from a session.',
-    'Dr. Lisa Thompson',
     'https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?w=500&h=300&fit=crop',
     5,
     (SELECT id FROM categories WHERE name = 'Physical Therapy')


### PR DESCRIPTION
Removes the author and date published fields from the blog feature, both on the frontend and backend.

- Updates the `posts` table schema to remove the `author` column.
- Updates the seed data to no longer include author information.
- Removes the author and date from the blog list and blog post pages.
- Removes the author field from the blog post creation/edit form.