### PR TITLE
feat: Add dropdown for image insertion and fix validation

### DIFF
--- a/src/components/GuidePostForm.tsx
+++ b/src/components/GuidePostForm.tsx
@@ -159,7 +159,13 @@ const GuidePostForm: React.FC<GuidePostFormProps> = ({ initialData, translations
                   <FormControl>
                     <RichTextEditor
                       content={field.value || ''}
-                      onChange={field.onChange}
+                      onChange={(content) => {
+                        if (content === '<p></p>') {
+                          field.onChange('');
+                        } else {
+                          field.onChange(content);
+                        }
+                      }}
                     />
                   </FormControl>
                   <FormMessage />

--- a/src/components/RichTextEditor.tsx
+++ b/src/components/RichTextEditor.tsx
@@ -14,6 +14,7 @@ import TableHeader from '@tiptap/extension-table-header';
 import TableCell from '@tiptap/extension-table-cell';
 import { Bold, Italic, Underline as UnderlineIcon, Link as LinkIcon, Heading2, Minus, Strikethrough, Quote, Image as ImageIcon, AlignLeft, AlignCenter, AlignRight, Pilcrow, Table as TableIcon, Trash, CornerUpLeft, CornerUpRight, Columns, Rows } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { supabase } from '@/integrations/supabase/client';
 
 interface RichTextEditorProps {
@@ -74,6 +75,15 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({ content, onChange }) =>
     }
 
     editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run();
+  };
+
+  const addImageUrl = () => {
+    if (!editor) return;
+    const url = window.prompt('Image URL');
+
+    if (url) {
+      editor.chain().focus().setImage({ src: url }).run();
+    }
   };
 
   const handleImageUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -177,15 +187,26 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({ content, onChange }) =>
         >
           <Minus className="h-4 w-4" />
         </Button>
-        <Button
-          onClick={() => fileInputRef.current?.click()}
-          variant={'ghost'}
-          size="sm"
-          type="button"
-          title="Image"
-        >
-          <ImageIcon className="h-4 w-4" />
-        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant={'ghost'}
+              size="sm"
+              type="button"
+              title="Image"
+            >
+              <ImageIcon className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem onClick={addImageUrl}>
+              Add from URL
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => fileInputRef.current?.click()}>
+              Upload Image
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
         <Button
           onClick={() => editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run()}
           variant={'ghost'}


### PR DESCRIPTION
- Replaced the single 'add image' button with a dropdown menu that provides two options: 'Add from URL' and 'Upload Image'.
- The 'Add from URL' option prompts the user for an image URL.
- The 'Upload Image' option opens the file dialog for local image uploads.
- Fixed a bug in the guide creation form where the 'What's next' field, when left empty, would prevent form submission. This was resolved by ensuring that the empty state of the rich text editor is correctly handled in the form's `onChange` event.