### PR TITLE
feat: implement path-based i18n and fix related bugs

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,205 +2,343 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ortho.life/</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://ortho.life/appointment</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ortho.life/pharmacy</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ortho.life/diagnostics</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ortho.life/faqs</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://ortho.life/resources</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://ortho.life/legal</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://ortho.life/upload-prescription</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/track-test-results</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/4</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/1</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/2</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/3</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/7</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/9</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/5</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/8</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/12</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/10</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/11</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/blog/7</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/blog/3</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/blog/2</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/blog/5</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/blog/4</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/blog/1</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/blog/8</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/blog/11</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/blog/10</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/blog/9</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/blog/12</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/4</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/2</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/1</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/5</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/7</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/10</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/9</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/11</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/12</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/3</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/8</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/6</loc>
-    <lastmod>2025-09-06T15:58:55.614Z</lastmod>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/guides/9</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/guides/5</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/guides/1</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/guides/12</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/guides/4</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/guides/7</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/guides/2</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/guides/11</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/guides/6</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/guides/10</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/guides/8</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://ortho.life/te/guides/3</loc>
+    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -10,6 +10,7 @@ export const LanguageSwitcher = () => {
   const navigate = useNavigate();
 
   const changeLanguage = (lng: string) => {
+    i18n.changeLanguage(lng);
     const currentPath = location.pathname;
     let newPath;
 
@@ -17,7 +18,7 @@ export const LanguageSwitcher = () => {
       if (!currentPath.startsWith('/te')) {
         newPath = `/te${currentPath}`;
       }
-    } else {
+    } else { // lng === 'en'
       if (currentPath.startsWith('/te')) {
         newPath = currentPath.substring(3);
       }
@@ -25,8 +26,6 @@ export const LanguageSwitcher = () => {
 
     if (newPath) {
       navigate(newPath);
-    } else {
-      i18n.changeLanguage(lng);
     }
   };
 

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -40,21 +40,16 @@ const BlogPostPage = () => {
   const { toast } = useToast();
 
   const handleShare = async () => {
-  const baseUrl = `${window.location.origin}${window.location.pathname}`;
-  const shareUrl = i18n.language && i18n.language !== 'en'
-    ? `${baseUrl}?lang=${i18n.language}`
-    : baseUrl;
-    
     const shareData = {
       title: translatedPost?.title || post.title,
       text: `Check out this article from OrthoLife: ${translatedPost?.title || post.title}`,
-      url: shareUrl,
+      url: window.location.href,
     };
     try {
       if (navigator.share && post) {
         await navigator.share(shareData);
       } else {
-        await navigator.clipboard.writeText(shareUrl);
+        await navigator.clipboard.writeText(window.location.href);
         toast({
           title: "Link Copied!",
           description: "The article link has been copied to your clipboard.",

--- a/src/pages/PatientGuidePage.tsx
+++ b/src/pages/PatientGuidePage.tsx
@@ -81,21 +81,16 @@ const PatientGuidePage = () => {
   }, [guideId, i18n.language]);
 
     const handleShare = async () => {
-    const baseUrl = `${window.location.origin}${window.location.pathname}`;
-    const shareUrl = i18n.language && i18n.language !== 'en'
-      ? `${baseUrl}?lang=${i18n.language}`
-      : baseUrl;
-
     const shareData = {
       title: translatedGuide?.title || guide.title,
       text: `Check out this patient guide from OrthoLife: ${translatedGuide?.title || guide.title}`,
-      url: shareUrl,
+      url: window.location.href,
     };
     try {
       if (navigator.share && guide) {
         await navigator.share(shareData);
       } else {
-        await navigator.clipboard.writeText(shareUrl);
+        await navigator.clipboard.writeText(window.location.href);
         toast({
           title: "Link Copied!",
           description: "The guide link has been copied to your clipboard.",


### PR DESCRIPTION
This commit implements a path-based internationalization (i18n) strategy for the blog and guide pages, with support for Telugu (`te`) translations. It also fixes two related bugs in the share button and the language switcher.

The changes include:
- The `generate-dynamic-routes.js` script now fetches both English and Telugu content from Supabase and generates routes with a `/te/` prefix for Telugu.
- The application's routing, language detection, and language switcher have been updated to support the new path-based i18n strategy.
- The share buttons on the blog and guide pages now correctly share the path-based URL for the current language.
- The language switcher now updates both the URL and the content on the first click.