### PR TITLE
fix: resolve issues with i18n routing and functionality

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,343 +2,343 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ortho.life/</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://ortho.life/appointment</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://ortho.life/pharmacy</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ortho.life/diagnostics</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://ortho.life/faqs</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://ortho.life/resources</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://ortho.life/legal</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://ortho.life/upload-prescription</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/track-test-results</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/4</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/1</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/2</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/3</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/7</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/9</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/5</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/8</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/12</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/10</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/blog/11</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/blog/7</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/blog/3</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/blog/2</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/blog/5</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/blog/4</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/blog/1</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/blog/8</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/blog/11</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/blog/10</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/blog/9</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/blog/12</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/4</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/2</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/1</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/5</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/7</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/10</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/9</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/11</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/12</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/3</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/8</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/guides/6</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/guides/9</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/guides/5</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/guides/1</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/guides/12</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/guides/4</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/guides/7</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/guides/2</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/guides/11</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/guides/6</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/guides/10</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/guides/8</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://ortho.life/te/guides/3</loc>
-    <lastmod>2025-09-06T16:59:39.299Z</lastmod>
+    <lastmod>2025-09-06T17:18:51.653Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,11 +69,13 @@ const App = () => {
 
                 {/* Learn Routes */}
                 <Route path="/blog" element={<BlogPage />} />
+                <Route path="/te/blog" element={<BlogPage />} />
                 <Route path="/blog/new" element={<CreatePostPage />} />
                 <Route path="/blog/:postId" element={<BlogPostPage />} />
                 <Route path="/te/blog/:postId" element={<BlogPostPage />} />
                 <Route path="/blog/:postId/edit" element={<EditPostPage />} />
                 <Route path="/guides" element={<PatientGuidesPage />} />
+                <Route path="/te/guides" element={<PatientGuidesPage />} />
                 <Route path="/guides/new" element={<CreateGuidePage />} />
                 <Route path="/guides/:guideId" element={<PatientGuidePage />} />
                 <Route path="/te/guides/:guideId" element={<PatientGuidePage />} />


### PR DESCRIPTION
This commit fixes several bugs related to the new path-based internationalization (i18n) system:
- Adds the missing routes for the Telugu versions of the blog and guide listing pages (`/te/blog` and `/te/guides`), which resolves a crash when switching languages on those pages.
- Updates the `LanguageSwitcher` component to correctly update both the URL and the content on the first click.
- Updates the `handleShare` function in the blog and guide pages to share the correct path-based URL for the current language.