### PR TITLE
feat: Populate empty "What's Next" field with default message

### DIFF
--- a/src/pages/EditGuidePage.tsx
+++ b/src/pages/EditGuidePage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import GuidePostForm, { GuideFormValues } from '@/components/GuidePostForm';
@@ -20,6 +21,7 @@ const EditGuidePage = () => {
   const navigate = useNavigate();
   const { guideId } = useParams<{ guideId: string }>();
   const { toast } = useToast();
+  const { t } = useTranslation();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [initialData, setInitialData] = useState<Partial<GuideFormValues> | null>(null);
   const [translations, setTranslations] = useState<TranslationValues | null>(null);
@@ -89,14 +91,31 @@ const EditGuidePage = () => {
       if (updateError) throw updateError;
 
       // Upsert translations
-      const translationUpserts = Object.keys(newTranslations).map(lang => ({
-        guide_id: guideId,
-        language: lang,
-        title: newTranslations[lang].title,
-        description: newTranslations[lang].description,
-        content: newTranslations[lang].content,
-        next_steps: newTranslations[lang].next_steps,
-      }));
+      const processedTranslations = { ...newTranslations };
+
+      for (const lang in processedTranslations) {
+        const nextSteps = processedTranslations[lang].next_steps;
+        if (!nextSteps || nextSteps.trim() === '<p></p>' || nextSteps.trim() === '') {
+          processedTranslations[lang].next_steps = t('forms.defaultNextSteps', { lng: lang });
+        }
+      }
+
+      const translationUpserts = Object.keys(processedTranslations)
+        .map(lang => {
+          const translation = processedTranslations[lang];
+          if (translation.title || translation.description || translation.content || translation.next_steps) {
+            return {
+              guide_id: guideId,
+              language: lang,
+              title: translation.title,
+              description: translation.description,
+              content: translation.content,
+              next_steps: translation.next_steps,
+            };
+          }
+          return null;
+        })
+        .filter(Boolean);
 
       if (translationUpserts.length > 0) {
         const { error: translationError } = await supabase

--- a/src/pages/EditPostPage.tsx
+++ b/src/pages/EditPostPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import BlogPostForm, { PostFormValues } from '@/components/BlogPostForm';
@@ -33,6 +34,7 @@ const EditPostPage = () => {
   const { postId } = useParams<{ postId: string }>();
   const navigate = useNavigate();
   const { toast } = useToast();
+  const { t } = useTranslation();
   const [initialData, setInitialData] = useState<Partial<PostFormValues> | null>(null);
   const [translations, setTranslations] = useState<TranslationValues>({});
   const [loading, setLoading] = useState(true);
@@ -121,17 +123,26 @@ const EditPostPage = () => {
       if (postUpdateError) throw postUpdateError;
 
       // 2. Upsert translations into the new table
+      const processedTranslations = { ...translations };
+
+      for (const lang in processedTranslations) {
+        const nextSteps = processedTranslations[lang].next_steps;
+        if (!nextSteps || nextSteps.trim() === '<p></p>' || nextSteps.trim() === '') {
+          processedTranslations[lang].next_steps = t('forms.defaultNextSteps', { lng: lang });
+        }
+      }
+
       const translationUpserts = [];
-      for (const lang in translations) {
-        // Ensure that we only upsert if there is some translated content
-        if (translations[lang].title || translations[lang].excerpt || translations[lang].content || translations[lang].next_steps) {
+      for (const lang in processedTranslations) {
+        const translation = processedTranslations[lang];
+        if (translation.title || translation.excerpt || translation.content || translation.next_steps) {
           translationUpserts.push({
             post_id: postId,
             language: lang,
-            title: translations[lang].title,
-            excerpt: translations[lang].excerpt,
-            content: translations[lang].content,
-            next_steps: translations[lang].next_steps,
+            title: translation.title,
+            excerpt: translation.excerpt,
+            content: translation.content,
+            next_steps: translation.next_steps,
           });
         }
       }


### PR DESCRIPTION
This commit modifies the `EditPostPage` and `EditGuidePage` components to ensure that an empty "What's Next" field is populated with a default message before being saved.

Previously, submitting an edit with an empty "What's Next" field would result in an empty value being stored in the database. Now, the `handleSubmit` function in both edit pages checks if the `next_steps` field in the translations is empty (null, empty string, or an empty paragraph tag). If it is, the field is populated with a default, translated message fetched using the `i18next` translation hook.

This change aligns the behavior of the edit pages with the create pages, ensuring data consistency and providing a better user experience.