### PR TITLE
fix: Sanitize null 'next_steps' field on data load

### DIFF
--- a/src/pages/EditGuidePage.tsx
+++ b/src/pages/EditGuidePage.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import GuidePostForm, { GuideFormValues } from '@/components/GuidePostForm';
@@ -21,7 +20,6 @@ const EditGuidePage = () => {
   const navigate = useNavigate();
   const { guideId } = useParams<{ guideId: string }>();
   const { toast } = useToast();
-  const { t } = useTranslation();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [initialData, setInitialData] = useState<Partial<GuideFormValues> | null>(null);
   const [translations, setTranslations] = useState<TranslationValues | null>(null);
@@ -55,7 +53,12 @@ const EditGuidePage = () => {
         setInitialData(initialFormValues);
 
         const initialTranslations = translationData.reduce((acc, t) => {
-          acc[t.language] = { title: t.title, description: t.description, content: t.content, next_steps: t.next_steps };
+          acc[t.language] = {
+            title: t.title,
+            description: t.description,
+            content: t.content,
+            next_steps: t.next_steps || ''
+          };
           return acc;
         }, {});
         setTranslations(initialTranslations);
@@ -73,13 +76,7 @@ const EditGuidePage = () => {
   const handleSubmit = async (values: GuideFormValues, newTranslations: TranslationValues) => {
     setIsSubmitting(true);
     try {
-      // Create a mutable copy of values to potentially add default next_steps
-      const finalValues = { ...values };
-      if (!finalValues.next_steps || finalValues.next_steps.trim() === '<p></p>' || finalValues.next_steps.trim() === '') {
-          finalValues.next_steps = t('forms.defaultNextSteps'); // Default language is English
-      }
-
-      const { category_name, ...guideData } = finalValues;
+      const { category_name, ...guideData } = values;
 
       // ... (Category lookup/creation logic - same as in CreateGuidePage)
       const { data: category, error: categoryError } = await supabase
@@ -98,31 +95,14 @@ const EditGuidePage = () => {
       if (updateError) throw updateError;
 
       // Upsert translations
-      const processedTranslations = { ...newTranslations };
-
-      for (const lang in processedTranslations) {
-        const nextSteps = processedTranslations[lang].next_steps;
-        if (!nextSteps || nextSteps.trim() === '<p></p>' || nextSteps.trim() === '') {
-          processedTranslations[lang].next_steps = t('forms.defaultNextSteps', { lng: lang });
-        }
-      }
-
-      const translationUpserts = Object.keys(processedTranslations)
-        .map(lang => {
-          const translation = processedTranslations[lang];
-          if (translation.title || translation.description || translation.content || translation.next_steps) {
-            return {
-              guide_id: guideId,
-              language: lang,
-              title: translation.title,
-              description: translation.description,
-              content: translation.content,
-              next_steps: translation.next_steps,
-            };
-          }
-          return null;
-        })
-        .filter(Boolean);
+      const translationUpserts = Object.keys(newTranslations).map(lang => ({
+        guide_id: guideId,
+        language: lang,
+        title: newTranslations[lang].title,
+        description: newTranslations[lang].description,
+        content: newTranslations[lang].content,
+        next_steps: newTranslations[lang].next_steps,
+      }));
 
       if (translationUpserts.length > 0) {
         const { error: translationError } = await supabase

--- a/src/pages/EditPostPage.tsx
+++ b/src/pages/EditPostPage.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import BlogPostForm, { PostFormValues } from '@/components/BlogPostForm';
@@ -34,7 +33,6 @@ const EditPostPage = () => {
   const { postId } = useParams<{ postId: string }>();
   const navigate = useNavigate();
   const { toast } = useToast();
-  const { t } = useTranslation();
   const [initialData, setInitialData] = useState<Partial<PostFormValues> | null>(null);
   const [translations, setTranslations] = useState<TranslationValues>({});
   const [loading, setLoading] = useState(true);
@@ -77,7 +75,7 @@ const EditPostPage = () => {
               title: trans.title,
               excerpt: trans.excerpt,
               content: trans.content,
-              next_steps: trans.next_steps,
+              next_steps: trans.next_steps || '',
             };
           }
           setTranslations(newTranslations);
@@ -100,14 +98,8 @@ const EditPostPage = () => {
   const handleSubmit = async (values: PostFormValues, translations: { [lang: string]: { title?: string; excerpt?: string; content?: string; next_steps?: string; } }) => {
     setIsSubmitting(true);
     try {
-      // Create a mutable copy of values to potentially add default next_steps
-      const finalValues = { ...values };
-      if (!finalValues.next_steps || finalValues.next_steps.trim() === '<p></p>' || finalValues.next_steps.trim() === '') {
-          finalValues.next_steps = t('forms.defaultNextSteps'); // Default language is English
-      }
-
       // 1. Update the main post
-      const { category_name, ...postData } = finalValues;
+      const { category_name, ...postData } = values;
       const { data: category, error: categoryError } = await supabase
         .from('categories')
         .select('id')
@@ -130,26 +122,17 @@ const EditPostPage = () => {
       if (postUpdateError) throw postUpdateError;
 
       // 2. Upsert translations into the new table
-      const processedTranslations = { ...translations };
-
-      for (const lang in processedTranslations) {
-        const nextSteps = processedTranslations[lang].next_steps;
-        if (!nextSteps || nextSteps.trim() === '<p></p>' || nextSteps.trim() === '') {
-          processedTranslations[lang].next_steps = t('forms.defaultNextSteps', { lng: lang });
-        }
-      }
-
       const translationUpserts = [];
-      for (const lang in processedTranslations) {
-        const translation = processedTranslations[lang];
-        if (translation.title || translation.excerpt || translation.content || translation.next_steps) {
+      for (const lang in translations) {
+        // Ensure that we only upsert if there is some translated content
+        if (translations[lang].title || translations[lang].excerpt || translations[lang].content || translations[lang].next_steps) {
           translationUpserts.push({
             post_id: postId,
             language: lang,
-            title: translation.title,
-            excerpt: translation.excerpt,
-            content: translation.content,
-            next_steps: translation.next_steps,
+            title: translations[lang].title,
+            excerpt: translations[lang].excerpt,
+            content: translations[lang].content,
+            next_steps: translations[lang].next_steps,
           });
         }
       }


### PR DESCRIPTION
This commit fixes a bug in the 'Edit Post' and 'Edit Guide' pages where a `null` value for the `next_steps` field from the database would cause a Zod validation error ("Expected string, received null").

The `useEffect` hook in both `EditPostPage.tsx` and `EditGuidePage.tsx` has been modified to sanitize the data as it's fetched. Any `null` value for `next_steps` (for both the main content and its translations) is now converted to an empty string before being passed to the form component.

This prevents the validation error and allows the existing logic within the form components to correctly apply the default "What's Next" message upon submission.