### PR TITLE
fix: Correctly update translated 'What's next' field

### DIFF
--- a/src/components/BlogPostForm.tsx
+++ b/src/components/BlogPostForm.tsx
@@ -78,7 +78,7 @@ const BlogPostForm: React.FC<BlogPostFormProps> = ({ initialData, translations, 
     }
   }, [initialData, translations, form]);
 
-  const handleTranslationChange = (lang: string, field: 'title' | 'content' | 'excerpt', value: string) => {
+  const handleTranslationChange = (lang: string, field: 'title' | 'content' | 'excerpt' | 'next_steps', value: string) => {
     setTranslationValues(prev => ({
       ...prev,
       [lang]: {

--- a/src/components/GuidePostForm.tsx
+++ b/src/components/GuidePostForm.tsx
@@ -81,7 +81,7 @@ const GuidePostForm: React.FC<GuidePostFormProps> = ({ initialData, translations
     }
   }, [initialData, translations, form]);
 
-  const handleTranslationChange = (lang: string, field: 'title' | 'description' | 'content', value: string) => {
+  const handleTranslationChange = (lang: string, field: 'title' | 'description' | 'content' | 'next_steps', value: string) => {
     setTranslationValues(prev => ({
       ...prev,
       [lang]: {


### PR DESCRIPTION
The 'What's next' field was not being saved correctly for translated content in the blog and guide forms. This was due to a TypeScript error in the `handleTranslationChange` function, which did not include `'next_steps'` in its type definition for the `field` parameter.

This change adds `'next_steps'` to the type definition, allowing the `handleTranslationChange` function to correctly update the component's state with the translated 'What's next' text. This ensures that user-provided content is preserved and not overwritten by the default text on form submission.