### PR TITLE
Fix: Ensure 'What's next' field is correctly populated on form submis…

### DIFF
--- a/src/components/BlogPostForm.tsx
+++ b/src/components/BlogPostForm.tsx
@@ -172,7 +172,13 @@ const BlogPostForm: React.FC<BlogPostFormProps> = ({ initialData, translations, 
                   <FormControl>
                     <RichTextEditor
                       content={field.value || ''}
-                      onChange={field.onChange}
+                      onChange={(content) => {
+                        if (content === '<p></p>') {
+                          field.onChange('');
+                        } else {
+                          field.onChange(content);
+                        }
+                      }}
                     />
                   </FormControl>
                   <FormMessage />


### PR DESCRIPTION
…sion.

This commit addresses an issue where the 'What's next' field was not being correctly populated with default localized text when left empty in the blog and guide forms.

The root cause was two-fold:
1. A TypeScript type error in the `handleTranslationChange` function prevented the translated 'What's next' field from being saved correctly.
2. The English 'What's next' field was not correctly handling empty content from the `RichTextEditor`, which prevented the existing form submission logic from triggering.

This commit resolves these issues by:
- Updating the type definition in `handleTranslationChange` to include 'next_steps'.
- Adding an `onChange` handler to the English 'What's next' field to normalize empty editor content to an empty string.

These changes ensure that the existing logic in the `handleFormSubmit` function works as intended for both English and translated content.