### PR TITLE
Refactor: Remove default population of 'What's next' field

### DIFF
--- a/src/pages/CreatePostPage.tsx
+++ b/src/pages/CreatePostPage.tsx
@@ -5,42 +5,16 @@ import Footer from '@/components/Footer';
 import BlogPostForm, { PostFormValues } from '@/components/BlogPostForm';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/components/ui/use-toast';
-import { useTranslation } from 'react-i18next';
 
 const CreatePostPage = () => {
   const navigate = useNavigate();
   const { toast } = useToast();
-  const { t } = useTranslation();
   const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const populateEmptyNextSteps = (values: PostFormValues, translations: { [lang: string]: { title?: string; excerpt?: string; content?: string; next_steps?: string; } }) => {
-    // Handle English next_steps (main form)
-    const updatedValues = { ...values };
-    if (!values.next_steps || values.next_steps.trim() === '') {
-      updatedValues.next_steps = t('forms.defaultNextSteps');
-    }
-
-    // Handle translations next_steps
-    const updatedTranslations = { ...translations };
-    Object.keys(translations).forEach(lang => {
-      if (!translations[lang].next_steps || translations[lang].next_steps?.trim() === '') {
-        updatedTranslations[lang] = {
-          ...translations[lang],
-          next_steps: t('forms.defaultNextSteps', { lng: lang })
-        };
-      }
-    });
-
-    return { updatedValues, updatedTranslations };
-  };
 
   const handleSubmit = async (values: PostFormValues, translations: { [lang: string]: { title?: string; excerpt?: string; content?: string; next_steps?: string; } }) => {
     setIsSubmitting(true);
     try {
-      // Populate empty next_steps with localized defaults
-      const { updatedValues, updatedTranslations } = populateEmptyNextSteps(values, translations);
-
-      const { category_name, ...postData } = updatedValues;
+      const { category_name, ...postData } = values;
 
       // Check if category exists
       const { data: category, error: categoryError } = await supabase
@@ -82,16 +56,16 @@ const CreatePostPage = () => {
       if (error) throw error;
       if (!newPost) throw new Error("Failed to create post.");
 
-      // Insert translations with populated next_steps
+      // Insert translations
       const translationUpserts = [];
-      for (const lang in updatedTranslations) {
+      for (const lang in translations) {
         translationUpserts.push({
           post_id: newPost.id,
           language: lang,
-          title: updatedTranslations[lang].title,
-          excerpt: updatedTranslations[lang].excerpt,
-          content: updatedTranslations[lang].content,
-          next_steps: updatedTranslations[lang].next_steps,
+          title: translations[lang].title,
+          excerpt: translations[lang].excerpt,
+          content: translations[lang].content,
+          next_steps: translations[lang].next_steps,
         });
       }
 


### PR DESCRIPTION
This commit removes the logic that automatically populated the 'What's next' field with default localized text if it was left empty.

The form submission logic has been removed from both `BlogPostForm.tsx` and `GuidePostForm.tsx`, and the `useTranslation` hook is no longer used in these components. The forms now submit the raw values, allowing the 'What's next' field to be saved as an empty string if the user leaves it blank.

This change was made to align with the new requirement to accept empty 'What's next' fields without any default text or localization.