### PR TITLE
feat: Allow individual medicine ordering and fix stock updates

### DIFF
--- a/src/pages/PharmacyPage.tsx
+++ b/src/pages/PharmacyPage.tsx
@@ -279,15 +279,25 @@ const PharmacyPage = () => {
             }
         }
 
-        let displayName;
+        let nameForStockUpdate = medicine.name;
         if (medicine.isGrouped && size) {
-          displayName = `${medicine.name} ${size}`;
+            nameForStockUpdate = `${medicine.name} ${size}`;
+        }
+
+        let displayNameForEmail = medicine.name;
+        if (medicine.isGrouped && size) {
+          displayNameForEmail = `${medicine.name} (${size})`;
+        }
+
+        const orderType = cartKey.endsWith('-unit') ? 'unit' : 'pack';
+        if (orderType === 'unit') {
+            displayNameForEmail = `${displayNameForEmail} (Units)`;
         } else {
-          displayName = medicine.name;
+            displayNameForEmail = `${displayNameForEmail} (Pack)`;
         }
         
         let itemPrice = 0;
-        if (cartKey.endsWith('-unit') && medicine.packSize) {
+        if (orderType === 'unit' && medicine.packSize) {
           const packSize = parseInt(medicine.packSize, 10);
           if (!isNaN(packSize) && packSize > 0) {
             itemPrice = medicine.price / packSize;
@@ -296,10 +306,9 @@ const PharmacyPage = () => {
           itemPrice = medicine.price;
         }
 
-        const orderType = cartKey.endsWith('-unit') ? 'unit' : 'pack';
-
         return {
-          name: displayName,
+          name: nameForStockUpdate,
+          displayName: displayNameForEmail,
           quantity,
           price: itemPrice,
           orderType: orderType,

--- a/supabase/functions/send-order-email/index.ts
+++ b/supabase/functions/send-order-email/index.ts
@@ -14,7 +14,7 @@ const handler = async (req)=>{
   }
   try {
     const { orderType, patientData, items, total } = await req.json();
-    const itemsList = items.map((item)=>`- ${item.name} x${item.quantity} - ₹${item.price * item.quantity}`).join('\n');
+    const itemsList = items.map((item)=>`- ${item.displayName} x${item.quantity} - ₹${item.price * item.quantity}`).join('\n');
     const subject = orderType === 'pharmacy' ? 'New Pharmacy Order' : 'New Diagnostics Booking';
     const toEmails = orderType === 'pharmacy' ? [
       "gangrenesoul@gmail.com",


### PR DESCRIPTION
This feature allows users to order individual units of a medicine from the pharmacy page, in addition to ordering a full pack.

- This functionality is enabled only for medicines with the `individual: "TRUE"` property and a `packSize` greater than 1.
- The price per unit is displayed on the product card for eligible medicines.
- The cart and total pricing are adjusted based on whether the user selects to order by pack or by individual unit.
- The order submission logic has been updated to correctly reflect the ordered items and their prices.
- The backend function `update-pharmacy-stock` has been modified to correctly handle stock updates for both packs and individual units.
- A bug in the search functionality that caused a crash with incomplete data has been fixed.
- The `send-order-email` function has been updated to use a more descriptive name for items in the email body.