### PR TITLE
feat: Allow individual medicine ordering and fix stock updates

### DIFF
--- a/supabase/functions/update-pharmacy-stock/index.ts
+++ b/supabase/functions/update-pharmacy-stock/index.ts
@@ -31,6 +31,10 @@ async function updateStockInSheet(accessToken, stockUpdates) {
   // Prepare batch update requests
   const batchUpdateData = [];
   for (const update of stockUpdates){
+    console.log('Processing update for:', update.name);
+    console.log('Order type:', update.orderType);
+    console.log('Pack size:', update.packSize);
+    console.log('Original quantity:', update.quantity);
     // Find the row for this medicine
     const rowIndex = values.findIndex((row, index)=>index > 0 && row[nameIndex]?.toLowerCase().trim() === update.name.toLowerCase().trim());
     if (rowIndex !== -1) {


### PR DESCRIPTION
This feature allows users to order individual units of a medicine from the pharmacy page, in addition to ordering a full pack.

- This functionality is enabled only for medicines with the `individual: "TRUE"` property and a `packSize` greater than 1.
- The price per unit is displayed on the product card for eligible medicines.
- The cart and total pricing are adjusted based on whether the user selects to order by pack or by individual unit.
- The order submission logic has been updated to correctly reflect the ordered items and their prices.
- The backend function `update-pharmacy-stock` has been modified to correctly handle stock updates for both packs and individual units.
- A bug in the search functionality that caused a crash with incomplete data has been fixed.
- The `send-order-email` function has been updated to use a more descriptive name for items in the email body, improving clarity for users and pharmacy staff.
- Added logging to the `update-pharmacy-stock` function for easier debugging of stock update issues.