### PR TITLE
fix: Correct stock validation and update logic for unit orders

### DIFF
--- a/src/pages/PharmacyPage.tsx
+++ b/src/pages/PharmacyPage.tsx
@@ -238,12 +238,30 @@ const PharmacyPage = () => {
     for (const [cartKey, quantity] of Object.entries(cart)) {
       const cartKeyParts = cartKey.split('-');
       const medicineId = cartKeyParts[0];
-      const size = cartKeyParts.length > 1 ? cartKeyParts.slice(1).join('-') : undefined;
       const medicine = medicines.find(m => m.id === medicineId);
+
       if (medicine) {
-        const availableStock = getAvailableStock(medicine, size);
+        const orderType = cartKey.endsWith('-unit') ? 'unit' : 'pack';
+
+        let size;
+        if (medicine.isGrouped) {
+            if (cartKey.endsWith('-unit') || cartKey.endsWith('-pack')) {
+                size = cartKeyParts.slice(1, cartKeyParts.length - 1).join('-');
+            } else {
+                size = cartKeyParts.slice(1).join('-');
+            }
+        }
+
+        const availableStock = getAvailableStock(medicine, size, orderType);
+
         if (quantity > availableStock) {
-          const displayName = medicine.isGrouped && size ? `${medicine.name} (${size})` : medicine.name;
+          let displayName = medicine.name;
+          if (medicine.isGrouped && size) {
+            displayName = `${medicine.name} (${size})`;
+          }
+          if (orderType === 'unit') {
+            displayName = `${displayName} (Units)`;
+          }
           stockErrors.push(`${displayName}: Only ${availableStock} available, but ${quantity} in cart`);
         }
       }


### PR DESCRIPTION
This commit fixes a bug in the checkout process where the stock validation was not correctly handling individual unit orders. It also includes the full implementation for allowing individual medicine ordering and ensures the backend stock updates are correct.

- Corrected the stock validation logic in the `handleCheckout` function to properly account for both pack and unit orders.
- Enabled individual unit ordering for medicines with `individual: "TRUE"` and `packSize > 1`.
- Displayed price per unit on the product card.
- Adjusted cart and total pricing for unit-based orders.
- Updated the `update-pharmacy-stock` backend function to correctly calculate stock decrements for unit orders.
- Updated the `send-order-email` function to use a more descriptive name for items in the email body.
- Fixed a bug in the search functionality that caused a crash with incomplete data.