### PR TITLE
Fix: Update PDF generation to use code-based SVG logo

### DIFF
--- a/src/lib/pdfUtils.ts
+++ b/src/lib/pdfUtils.ts
@@ -46,13 +46,27 @@ const preloadImages = (htmlContent: string): Promise<void> => {
   }
 };
 
-export const generatePdf = async (htmlContent: string, filename: string) => {
-  let logoDataUri = '';
-  try {
-    logoDataUri = await imageToDataUri('/logo.png');
-  } catch (error) {
-    console.error("Failed to load logo for PDF, proceeding without it.", error);
-  }
+const generateLogoSvg = (backgroundColor: string): string => {
+  const svg = `
+    <svg width="280" height="50" viewBox="0 0 280 50" xmlns="http://www.w3.org/2000/svg">
+      <style>
+        .text {
+          font-family: Montserrat, sans-serif;
+          font-size: 40px;
+          font-weight: bold;
+          fill: hsl(199, 100%, 36%);
+        }
+      </style>
+      <text x="0" y="35" class="text">OrthoLife</text>
+      <rect x="0" y="15.5" width="112" height="4" fill="${backgroundColor}" />
+    </svg>
+  `;
+  return `data:image/svg+xml;base64,${btoa(svg)}`;
+};
+
+export const generatePdf = async (htmlContent: string, filename:string) => {
+  // The PDF background is white, so we use 'white' for the logo's strikethrough.
+  const logoDataUri = generateLogoSvg('white');
 
   await preloadImages(htmlContent);
 


### PR DESCRIPTION
The previous change to a code-based logo broke the PDF generation for guides, which was still referencing the deleted `logo.png`.

This commit fixes the issue by:
- Removing the dependency on a static logo file in `src/lib/pdfUtils.ts`.
- Introducing a new function, `generateLogoSvg`, that dynamically creates an SVG version of the logo as a data URI.
- Updating the `generatePdf` function to use this dynamically generated SVG.

This ensures that the PDF generation works correctly and uses a code-based, scalable logo, which is consistent with the initial change.